### PR TITLE
Add optional EOA execution via --execute and --keypair flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,32 @@ The CLI requires network configuration through either `--env` or `--rpc-url`:
 | `testnet`   | https://api.testnet.solana.com      |
 | `localhost` | http://localhost:8899               |
 
+#### EOA Execution
+
+By default, the CLI generates unsigned Base58 transaction data for multisig import (e.g. Squads). To sign and send directly with a local keypair, add `--execute`:
+
+```bash
+# Uses default keypair at ~/.config/solana/id.json
+pnpm bs58 --env devnet --execute \
+  burnmint-token-pool --instruction accept-ownership \
+  --program-id "Your_Program_ID" \
+  --mint "Token_Mint_Address" \
+  --authority "Your_EOA_PublicKey"
+
+# Custom keypair path
+pnpm bs58 --env devnet --execute --keypair ~/my-wallet.json \
+  spl-token --instruction mint \
+  --mint "Token_Mint" --authority "Your_EOA_PublicKey" ...
+```
+
+**Requirements and limitations:**
+
+- `--authority` must match the loaded keypair's public key (the EOA is the fee payer and signer)
+- `--execute` requires `--env` or `--rpc-url`
+- `--keypair` can only be used with `--execute`
+- Multisig vault addresses cannot be executed locally — omit `--execute` and import Base58 into Squads
+- Read-only commands (`get-state`, `get-chain-config`, `derive-accounts`) do not support `--execute`
+
 ## Programs
 
 ### Burnmint Token Pool

--- a/src/commands/burnmint/index.ts
+++ b/src/commands/burnmint/index.ts
@@ -12,6 +12,7 @@ import { appendRemotePoolAddressesCommand } from './append-remote-pool-addresses
 import { deleteChainConfigCommand } from './delete-chain-config.js';
 import { configureAllowListCommand } from './configure-allow-list.js';
 import { removeFromAllowListCommand } from './remove-from-allow-list.js';
+import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 /**
  * Burnmint Token Pool commands
@@ -126,6 +127,7 @@ export function createBurnmintCommands(): Command {
         console.error('❌ --execute is not supported for read-only instructions');
         process.exit(1);
       }
+      applyExecuteAuthority(thisCommand, options, globalOpts);
       if (!readOnlyInstructions.includes(options.instruction) && !options.authority) {
         console.error('❌ This instruction requires: --authority');
         console.error(

--- a/src/commands/burnmint/index.ts
+++ b/src/commands/burnmint/index.ts
@@ -122,6 +122,10 @@ export function createBurnmintCommands(): Command {
 
       // Most instructions also require --authority (except read-only operations)
       const readOnlyInstructions = ['get-state', 'get-chain-config'];
+      if (globalOpts.execute && readOnlyInstructions.includes(options.instruction)) {
+        console.error('❌ --execute is not supported for read-only instructions');
+        process.exit(1);
+      }
       if (!readOnlyInstructions.includes(options.instruction) && !options.authority) {
         console.error('❌ This instruction requires: --authority');
         console.error(

--- a/src/commands/lockrelease/index.ts
+++ b/src/commands/lockrelease/index.ts
@@ -16,6 +16,7 @@ import { provideLiquidityCommand } from './provide-liquidity.js';
 import { withdrawLiquidityCommand } from './withdraw-liquidity.js';
 import { setRebalancerCommand } from './set-rebalancer.js';
 import { setCanAcceptLiquidityCommand } from './set-can-accept-liquidity.js';
+import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 /**
  * Lock/Release Token Pool commands
@@ -149,6 +150,7 @@ export function createLockReleaseCommands(): Command {
         console.error('❌ --execute is not supported for read-only instructions');
         process.exit(1);
       }
+      applyExecuteAuthority(thisCommand, options, globalOpts);
       if (!readOnlyInstructions.includes(options.instruction) && !options.authority) {
         console.error('❌ This instruction requires: --authority');
         console.error(

--- a/src/commands/lockrelease/index.ts
+++ b/src/commands/lockrelease/index.ts
@@ -145,6 +145,10 @@ export function createLockReleaseCommands(): Command {
 
       // Most instructions also require --authority (except read-only operations)
       const readOnlyInstructions = ['get-state', 'get-chain-config'];
+      if (globalOpts.execute && readOnlyInstructions.includes(options.instruction)) {
+        console.error('❌ --execute is not supported for read-only instructions');
+        process.exit(1);
+      }
       if (!readOnlyInstructions.includes(options.instruction) && !options.authority) {
         console.error('❌ This instruction requires: --authority');
         console.error(

--- a/src/commands/lockrelease/provide-liquidity.ts
+++ b/src/commands/lockrelease/provide-liquidity.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { ProvideLiquidityArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig } from '../../types/program-registry.js';
 import type { CommandContext, ProvideLiquidityOptions } from '../../types/command.js';
@@ -123,15 +123,14 @@ export async function provideLiquidityCommand(
 
     // Build the complete transaction
     console.log('🔄 Building and simulating transaction...');
-    const transaction = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      validatedArgs.authority,
-      'provideLiquidity'
-    );
+    const transaction = await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: validatedArgs.authority,
+      instructionName: 'provideLiquidity',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    // Display results
-    TransactionDisplay.displayResults(transaction, 'provideLiquidity');
 
     cmdLogger.info(
       {

--- a/src/commands/lockrelease/set-can-accept-liquidity.ts
+++ b/src/commands/lockrelease/set-can-accept-liquidity.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { SetCanAcceptLiquidityArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig } from '../../types/program-registry.js';
 import type { CommandContext, SetCanAcceptLiquidityOptions } from '../../types/command.js';
@@ -100,15 +100,14 @@ export async function setCanAcceptLiquidityCommand(
 
     // Build the complete transaction
     console.log('🔄 Building and simulating transaction...');
-    const transaction = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      validatedArgs.authority,
-      'setCanAcceptLiquidity'
-    );
+    const transaction = await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: validatedArgs.authority,
+      instructionName: 'setCanAcceptLiquidity',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    // Display results
-    TransactionDisplay.displayResults(transaction, 'setCanAcceptLiquidity');
 
     cmdLogger.info(
       {

--- a/src/commands/lockrelease/set-rebalancer.ts
+++ b/src/commands/lockrelease/set-rebalancer.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { SetRebalancerArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig } from '../../types/program-registry.js';
 import type { CommandContext, SetRebalancerOptions } from '../../types/command.js';
@@ -100,15 +100,14 @@ export async function setRebalancerCommand(
 
     // Build the complete transaction
     console.log('🔄 Building and simulating transaction...');
-    const transaction = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      validatedArgs.authority,
-      'setRebalancer'
-    );
+    const transaction = await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: validatedArgs.authority,
+      instructionName: 'setRebalancer',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    // Display results
-    TransactionDisplay.displayResults(transaction, 'setRebalancer');
 
     cmdLogger.info(
       {

--- a/src/commands/lockrelease/withdraw-liquidity.ts
+++ b/src/commands/lockrelease/withdraw-liquidity.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { WithdrawLiquidityArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig } from '../../types/program-registry.js';
 import type { CommandContext, WithdrawLiquidityOptions } from '../../types/command.js';
@@ -123,15 +123,14 @@ export async function withdrawLiquidityCommand(
 
     // Build the complete transaction
     console.log('🔄 Building and simulating transaction...');
-    const transaction = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      validatedArgs.authority,
-      'withdrawLiquidity'
-    );
+    const transaction = await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: validatedArgs.authority,
+      instructionName: 'withdrawLiquidity',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    // Display results
-    TransactionDisplay.displayResults(transaction, 'withdrawLiquidity');
 
     cmdLogger.info(
       {

--- a/src/commands/metaplex/index.ts
+++ b/src/commands/metaplex/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { updateMetadataAuthorityCommand } from './update-authority.js';
+import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 export function createMetaplexCommands(): Command {
   const metaplex = new Command('metaplex')
@@ -17,6 +18,7 @@ export function createMetaplexCommands(): Command {
         process.exit(1);
       }
       const options = thisCommand.opts();
+      applyExecuteAuthority(thisCommand, options, globalOpts);
       const instr = options.instruction as string;
       if (instr === 'update-authority') {
         if (!options.authority || !options.mint || !options.newAuthority) {

--- a/src/commands/metaplex/update-authority.ts
+++ b/src/commands/metaplex/update-authority.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { TransactionInstruction, PublicKey } from '@solana/web3.js';
 import { validateArgs } from '../../utils/validation.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { MetaplexUpdateAuthorityArgsSchema } from '../../types/index.js';
 import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
 import { InstructionBuilder as MplInstructionBuilder } from '../../programs/metaplex/instructions.js';
@@ -42,13 +42,14 @@ export async function updateMetadataAuthorityCommand(
   const ixs: TransactionInstruction[] = [ix];
   const tb = new TransactionBuilder({ rpcUrl });
   logger.info('🔄 Building and simulating transaction...');
-  const tx = await tb.buildTransaction(
-    ixs,
-    parsed.data.authority as PublicKey,
-    'metaplex.update_authority'
-  );
+  await finalizeTransaction({
+    txBuilder: tb,
+    instructions: ixs,
+    payer: parsed.data.authority as PublicKey,
+    instructionName: 'metaplex.update_authority',
+    command,
+  });
   logger.info('✅ Transaction simulation completed');
-  TransactionDisplay.displayResults(tx, 'metaplex.update_authority');
 }
 
 /**

--- a/src/commands/router/accept-admin-role.ts
+++ b/src/commands/router/accept-admin-role.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { RouterAcceptAdminRoleArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { InstructionBuilder } from '../../programs/router/instructions.js';
 import { getProgramConfig } from '../../types/program-registry.js';
@@ -51,14 +51,14 @@ export async function acceptAdminRoleCommand(
     const instruction = await instructionBuilder.acceptAdminRoleTokenAdminRegistry(mint, authority);
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      authority!,
-      'router.accept_admin_role_token_admin_registry'
-    );
+    await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: authority!,
+      instructionName: 'router.accept_admin_role_token_admin_registry',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, 'router.accept_admin_role_token_admin_registry');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     cmdLogger.error({ error: message }, 'acceptAdminRole failed');

--- a/src/commands/router/append-to-lookup-table.ts
+++ b/src/commands/router/append-to-lookup-table.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { Connection } from '@solana/web3.js';
 import { validateArgs } from '../../utils/validation.js';
 import { RouterAppendToLookupTableArgsSchema } from '../../types/index.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionDisplay } from '../../utils/display.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { buildAppendToAlt, deriveCcipBaseAddresses } from '../../utils/alt.js';
@@ -113,12 +114,6 @@ export async function appendToLookupTableCommand(
     const txBuilder = new TransactionBuilder({ rpcUrl });
     cmdLogger.info('🔄 Building and simulating transaction...');
 
-    const generated = await txBuilder.buildTransaction(
-      instructions,
-      parsed.data.authority,
-      'router.append_to_lookup_table'
-    );
-
     // Display success info before transaction details
     console.log(`📮 Lookup Table Address: ${parsed.data.lookupTableAddress.toBase58()}`);
     if (hasCcipParams) {
@@ -130,9 +125,15 @@ export async function appendToLookupTableCommand(
       console.log(`📊 Addresses added: ${parsed.data.additionalAddresses.length}`);
     }
     console.log(`📈 Total addresses after append: ${totalAddressesAfterAppend}`);
-    console.log('   ✅ Transaction simulation completed');
 
-    TransactionDisplay.displayResults(generated, 'router.append_to_lookup_table');
+    await finalizeTransaction({
+      txBuilder,
+      instructions,
+      payer: parsed.data.authority,
+      instructionName: 'router.append_to_lookup_table',
+      command,
+    });
+    console.log('   ✅ Transaction simulation completed');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (error instanceof Error && error.stack) {

--- a/src/commands/router/create-lookup-table.ts
+++ b/src/commands/router/create-lookup-table.ts
@@ -53,22 +53,28 @@ export async function createLookupTableCommand(options: Record<string, string>, 
     });
 
     console.log(`📮 Derived Lookup Table Address: ${lookupTableAddress.toBase58()}`);
-    console.log('   ✅ Transaction simulation completed');
-    console.log('');
-    console.log('⚠️  ALT CREATION TIMING CONSTRAINT');
-    console.log('   This transaction must be imported AND executed within 60-90 seconds');
-    console.log('   due to slot-dependent address derivation.');
-    console.log('');
-    console.log('💡 RECOMMENDED: Use the companion tool for immediate execution:');
-    console.log(
-      `   pnpm create-alt --keypair <EOA_KEYPAIR> --authority ${parsed.data.authority.toBase58()} \\`
-    );
-    console.log(`     --program-id ${parsed.data.programId.toBase58()} \\`);
-    console.log(`     --fee-quoter-program-id ${parsed.data.feeQuoterProgramId.toBase58()} \\`);
-    console.log(`     --pool-program-id ${parsed.data.poolProgramId.toBase58()} \\`);
-    console.log(`     --mint ${parsed.data.mint.toBase58()} \\`);
-    console.log(`     --env ${globalOptions.environment || 'mainnet'}`);
-    console.log('');
+
+    // The slot-expiry timing constraint only applies to the Base58 → Squads flow, where a human
+    // imports and executes the transaction later. In --execute mode the EOA signs immediately, so
+    // there is no race and the companion tool is not needed.
+    if (!globalOptions.execute) {
+      console.log('   ✅ Transaction simulation completed');
+      console.log('');
+      console.log('⚠️  ALT CREATION TIMING CONSTRAINT');
+      console.log('   This transaction must be imported AND executed within 60-90 seconds');
+      console.log('   due to slot-dependent address derivation.');
+      console.log('');
+      console.log('💡 RECOMMENDED: Use the companion tool for immediate execution:');
+      console.log(
+        `   pnpm create-alt --keypair <EOA_KEYPAIR> --authority ${parsed.data.authority.toBase58()} \\`
+      );
+      console.log(`     --program-id ${parsed.data.programId.toBase58()} \\`);
+      console.log(`     --fee-quoter-program-id ${parsed.data.feeQuoterProgramId.toBase58()} \\`);
+      console.log(`     --pool-program-id ${parsed.data.poolProgramId.toBase58()} \\`);
+      console.log(`     --mint ${parsed.data.mint.toBase58()} \\`);
+      console.log(`     --env ${globalOptions.environment || 'mainnet'}`);
+      console.log('');
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (error instanceof Error && error.stack) {

--- a/src/commands/router/create-lookup-table.ts
+++ b/src/commands/router/create-lookup-table.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { Connection } from '@solana/web3.js';
 import { validateArgs } from '../../utils/validation.js';
 import { RouterCreateLookupTableArgsSchema } from '../../types/index.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionDisplay } from '../../utils/display.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { buildCreateAndExtendAlt } from '../../utils/alt.js';
@@ -43,11 +44,13 @@ export async function createLookupTableCommand(options: Record<string, string>, 
 
     const txBuilder = new TransactionBuilder({ rpcUrl });
     console.log('🔄 Building and simulating transaction...');
-    const generated = await txBuilder.buildTransaction(
+    await finalizeTransaction({
+      txBuilder,
       instructions,
-      parsed.data.authority,
-      'router.create_lookup_table'
-    );
+      payer: parsed.data.authority,
+      instructionName: 'router.create_lookup_table',
+      command,
+    });
 
     console.log(`📮 Derived Lookup Table Address: ${lookupTableAddress.toBase58()}`);
     console.log('   ✅ Transaction simulation completed');
@@ -66,7 +69,6 @@ export async function createLookupTableCommand(options: Record<string, string>, 
     console.log(`     --mint ${parsed.data.mint.toBase58()} \\`);
     console.log(`     --env ${globalOptions.environment || 'mainnet'}`);
     console.log('');
-    TransactionDisplay.displayResults(generated, 'router.create_lookup_table');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (error instanceof Error && error.stack) {

--- a/src/commands/router/index.ts
+++ b/src/commands/router/index.ts
@@ -6,6 +6,7 @@ import { transferAdminRoleCommand } from './transfer-admin-role.js';
 import { setPoolCommand } from './set-pool.js';
 import { createLookupTableCommand } from './create-lookup-table.js';
 import { appendToLookupTableCommand } from './append-to-lookup-table.js';
+import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 /**
  * CCIP Router commands
@@ -60,6 +61,7 @@ export function createRouterCommands(): Command {
       }
 
       const options = thisCommand.opts();
+      applyExecuteAuthority(thisCommand, options, globalOpts);
 
       // common - append-to-lookup-table doesn't need program-id
       const instr = options.instruction as string;

--- a/src/commands/router/owner-override-pending-administrator.ts
+++ b/src/commands/router/owner-override-pending-administrator.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { RouterOwnerOverridePendingAdministratorArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { InstructionBuilder } from '../../programs/router/instructions.js';
 import { getProgramConfig } from '../../types/program-registry.js';
@@ -59,14 +59,14 @@ export async function ownerOverridePendingAdministratorCommand(
     );
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      authority!,
-      'router.owner_override_pending_administrator'
-    );
+    await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: authority!,
+      instructionName: 'router.owner_override_pending_administrator',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, 'router.owner_override_pending_administrator');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     cmdLogger.error({ error: message }, 'ownerOverridePendingAdministrator failed');

--- a/src/commands/router/owner-propose-administrator.ts
+++ b/src/commands/router/owner-propose-administrator.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { RouterOwnerProposeAdministratorArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { InstructionBuilder } from '../../programs/router/instructions.js';
 import { getProgramConfig } from '../../types/program-registry.js';
@@ -58,14 +58,14 @@ export async function ownerProposeAdministratorCommand(
     );
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      authority!,
-      'router.owner_propose_administrator'
-    );
+    await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: authority!,
+      instructionName: 'router.owner_propose_administrator',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, 'router.owner_propose_administrator');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     cmdLogger.error({ error: message }, 'ownerProposeAdministrator failed');

--- a/src/commands/router/set-pool.ts
+++ b/src/commands/router/set-pool.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { RouterSetPoolArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { InstructionBuilder } from '../../programs/router/instructions.js';
 import { getProgramConfig } from '../../types/program-registry.js';
@@ -67,14 +67,14 @@ export async function setPoolCommand(
     );
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      authority,
-      'router.set_pool'
-    );
+    await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: authority,
+      instructionName: 'router.set_pool',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, 'router.set_pool');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     cmdLogger.error({ error: message }, 'setPool failed');

--- a/src/commands/router/transfer-admin-role.ts
+++ b/src/commands/router/transfer-admin-role.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { RouterTransferAdminRoleArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { InstructionBuilder } from '../../programs/router/instructions.js';
 import { getProgramConfig } from '../../types/program-registry.js';
@@ -57,14 +57,14 @@ export async function transferAdminRoleCommand(
     );
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      authority!,
-      'router.transfer_admin_role_token_admin_registry'
-    );
+    await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: authority!,
+      instructionName: 'router.transfer_admin_role_token_admin_registry',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, 'router.transfer_admin_role_token_admin_registry');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     cmdLogger.error({ error: message }, 'transferAdminRole failed');

--- a/src/commands/shared/accept-ownership.ts
+++ b/src/commands/shared/accept-ownership.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { AcceptOwnershipArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, AcceptOwnershipOptions } from '../../types/command.js';
@@ -78,14 +78,14 @@ export async function acceptOwnership(
     console.log('   ✅ Instruction built successfully');
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await txBuilder.buildSingleInstructionTransaction(
-      ix,
-      authority,
-      `${programType}.accept-ownership`
-    );
+    const tx = await finalizeTransaction({
+      txBuilder,
+      instructions: [ix],
+      payer: authority,
+      instructionName: `${programType}.accept-ownership`,
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, `${programType}.accept-ownership`);
 
     cmdLogger.info(
       {

--- a/src/commands/shared/append-remote-pool-addresses.ts
+++ b/src/commands/shared/append-remote-pool-addresses.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { AppendRemotePoolAddressesArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, AppendRemotePoolAddressesOptions } from '../../types/command.js';
@@ -126,15 +126,14 @@ export async function appendRemotePoolAddresses(
 
     // Build the complete transaction (includes automatic simulation)
     console.log('🔄 Building and simulating transaction...');
-    const transaction = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      validatedArgs.authority,
-      'appendRemotePoolAddresses'
-    );
+    const transaction = await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: validatedArgs.authority,
+      instructionName: 'appendRemotePoolAddresses',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    // Display results using the beautiful utility
-    TransactionDisplay.displayResults(transaction, 'appendRemotePoolAddresses');
 
     cmdLogger.info(
       {

--- a/src/commands/shared/configure-allow-list.ts
+++ b/src/commands/shared/configure-allow-list.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { ConfigureAllowListArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, ConfigureAllowListOptions } from '../../types/command.js';
@@ -88,14 +88,14 @@ export async function configureAllowList(
     console.log('   ✅ Instruction built successfully');
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await txBuilder.buildSingleInstructionTransaction(
-      ix,
-      authority,
-      `${programType}.configure-allow-list`
-    );
+    const tx = await finalizeTransaction({
+      txBuilder,
+      instructions: [ix],
+      payer: authority,
+      instructionName: `${programType}.configure-allow-list`,
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, `${programType}.configure-allow-list`);
 
     cmdLogger.info(
       {

--- a/src/commands/shared/delete-chain-config.ts
+++ b/src/commands/shared/delete-chain-config.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { DeleteChainConfigArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, DeleteChainConfigOptions } from '../../types/command.js';
@@ -121,15 +121,14 @@ export async function deleteChainConfig(
 
     // Build the complete transaction (includes automatic simulation)
     console.log('🔄 Building and simulating transaction...');
-    const transaction = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      validatedArgs.authority,
-      'deleteChainConfig'
-    );
+    const transaction = await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: validatedArgs.authority,
+      instructionName: 'deleteChainConfig',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    // Display results using the beautiful utility
-    TransactionDisplay.displayResults(transaction, 'deleteChainConfig');
 
     cmdLogger.info(
       {

--- a/src/commands/shared/edit-chain-remote-config.ts
+++ b/src/commands/shared/edit-chain-remote-config.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { EditChainRemoteConfigArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, EditChainRemoteConfigOptions } from '../../types/command.js';
@@ -136,15 +136,14 @@ export async function editChainRemoteConfig(
 
     // Build the complete transaction (includes automatic simulation)
     console.log('🔄 Building and simulating transaction...');
-    const transaction = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      validatedArgs.authority,
-      'editChainRemoteConfig'
-    );
+    const transaction = await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: validatedArgs.authority,
+      instructionName: 'editChainRemoteConfig',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    // Display results using the beautiful utility
-    TransactionDisplay.displayResults(transaction, 'editChainRemoteConfig');
 
     cmdLogger.info(
       {

--- a/src/commands/shared/init-chain-remote-config.ts
+++ b/src/commands/shared/init-chain-remote-config.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { InitChainRemoteConfigArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, InitChainRemoteConfigOptions } from '../../types/command.js';
@@ -73,6 +73,20 @@ export async function initChainRemoteConfig(
 
     const validatedArgs = validation.data;
 
+    if (validatedArgs.poolAddresses.length > 0) {
+      console.error(
+        "❌ init-chain-remote-config requires empty pool addresses (use --pool-addresses '[]')"
+      );
+      console.error(
+        '💡 The on-chain program rejects non-empty pool addresses during init (error 6013: NonemptyPoolAddressesInit).'
+      );
+      console.error("💡 Step 1: init with --pool-addresses '[]'");
+      console.error(
+        "💡 Step 2: append pools with --instruction append-remote-pool-addresses --addresses '[...]'"
+      );
+      process.exit(1);
+    }
+
     // Since we verified rpcUrl exists in preAction hook, we can safely use it
     const rpcUrl = validatedArgs.rpcUrl || globalOptions.resolvedRpcUrl!;
 
@@ -118,12 +132,9 @@ export async function initChainRemoteConfig(
     console.log(`   Mint: ${validatedArgs.mint.toString()}`);
     console.log(`   Authority: ${validatedArgs.authority.toString()}`);
     console.log(`   Remote Chain Selector: ${validatedArgs.remoteChainSelector}`);
-    if (validatedArgs.poolAddresses.length > 0) {
-      console.warn(
-        '⚠️  For init-chain-remote-config, poolAddresses should generally be empty. Use append-remote-pool-addresses afterwards.'
-      );
-    }
-    console.log(`   Pool Addresses: ${validatedArgs.poolAddresses.length} addresses`);
+    console.log(
+      `   Pool Addresses: ${validatedArgs.poolAddresses.length} addresses (must be empty at init)`
+    );
     console.log(`   Token Address: ${validatedArgs.tokenAddress}`);
     console.log(`   Decimals: ${validatedArgs.decimals}`);
 
@@ -141,15 +152,14 @@ export async function initChainRemoteConfig(
 
     // Build the complete transaction (includes automatic simulation)
     console.log('🔄 Building and simulating transaction...');
-    const transaction = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      validatedArgs.authority,
-      'initChainRemoteConfig'
-    );
+    const transaction = await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: validatedArgs.authority,
+      instructionName: 'initChainRemoteConfig',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    // Display results using the beautiful utility
-    TransactionDisplay.displayResults(transaction, 'initChainRemoteConfig');
 
     cmdLogger.info(
       {
@@ -173,6 +183,14 @@ export async function initChainRemoteConfig(
       console.error('   • Mint: Base58 public key (44 characters)');
       console.error('   • Authority: Base58 public key (44 characters)');
       console.error('   Example: 11111111111111111111111111111112');
+    } else if (
+      errorMessage.includes('6013') ||
+      errorMessage.includes('NonemptyPoolAddressesInit')
+    ) {
+      console.error('❌ Pool addresses must be empty during init-chain-remote-config');
+      console.error(
+        "💡 Use --pool-addresses '[]' for init, then append-remote-pool-addresses for pool addresses."
+      );
     } else if (errorMessage.includes('Invalid JSON')) {
       console.error('❌ Invalid JSON format');
       console.error('💡 Expected format:');

--- a/src/commands/shared/initialize-pool.ts
+++ b/src/commands/shared/initialize-pool.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { BaseInitializePoolArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, InitializePoolOptions } from '../../types/command.js';
@@ -66,14 +66,14 @@ export async function initializePool(
     }
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await txBuilder.buildSingleInstructionTransaction(
-      ix,
-      authority,
-      `${programType}.initialize`
-    );
+    await finalizeTransaction({
+      txBuilder,
+      instructions: [ix],
+      payer: authority,
+      instructionName: `${programType}.initialize`,
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, `${programType}.initialize`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     cmdLogger.error({ error: message }, 'initializePool failed');

--- a/src/commands/shared/remove-from-allow-list.ts
+++ b/src/commands/shared/remove-from-allow-list.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { RemoveFromAllowListArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, RemoveFromAllowListOptions } from '../../types/command.js';
@@ -87,14 +87,14 @@ export async function removeFromAllowList(
     console.log('   ✅ Instruction built successfully');
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await txBuilder.buildSingleInstructionTransaction(
-      ix,
-      authority,
-      `${programType}.remove-from-allow-list`
-    );
+    const tx = await finalizeTransaction({
+      txBuilder,
+      instructions: [ix],
+      payer: authority,
+      instructionName: `${programType}.remove-from-allow-list`,
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, `${programType}.remove-from-allow-list`);
 
     cmdLogger.info(
       {

--- a/src/commands/shared/set-chain-rate-limit.ts
+++ b/src/commands/shared/set-chain-rate-limit.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { SetChainRateLimitArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, SetChainRateLimitOptions } from '../../types/command.js';
@@ -149,15 +149,14 @@ export async function setChainRateLimit(
 
     // Build the complete transaction (includes automatic simulation)
     console.log('🔄 Building and simulating transaction...');
-    const transaction = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      validatedArgs.authority,
-      'setChainRateLimit'
-    );
+    const transaction = await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: validatedArgs.authority,
+      instructionName: 'setChainRateLimit',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    // Display results using the beautiful utility
-    TransactionDisplay.displayResults(transaction, 'setChainRateLimit');
 
     cmdLogger.info(
       {

--- a/src/commands/shared/set-rate-limit-admin.ts
+++ b/src/commands/shared/set-rate-limit-admin.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { SetRateLimitAdminArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, SetRateLimitAdminOptions } from '../../types/command.js';
@@ -82,14 +82,14 @@ export async function setRateLimitAdmin(
     console.log('   ✅ Instruction built successfully');
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await txBuilder.buildSingleInstructionTransaction(
-      ix,
-      authority,
-      `${programType}.set-rate-limit-admin`
-    );
+    const tx = await finalizeTransaction({
+      txBuilder,
+      instructions: [ix],
+      payer: authority,
+      instructionName: `${programType}.set-rate-limit-admin`,
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, `${programType}.set-rate-limit-admin`);
 
     cmdLogger.info(
       {

--- a/src/commands/shared/transfer-ownership.ts
+++ b/src/commands/shared/transfer-ownership.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { TransferOwnershipArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { getProgramConfig, type ProgramName } from '../../types/program-registry.js';
 import type { CommandContext, TransferOwnershipOptions } from '../../types/command.js';
@@ -82,14 +82,14 @@ export async function transferOwnership(
     console.log('   ✅ Instruction built successfully');
 
     console.log('🔄 Building and simulating transaction...');
-    const tx = await txBuilder.buildSingleInstructionTransaction(
-      ix,
-      authority,
-      `${programType}.transfer-ownership`
-    );
+    const tx = await finalizeTransaction({
+      txBuilder,
+      instructions: [ix],
+      payer: authority,
+      instructionName: `${programType}.transfer-ownership`,
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    TransactionDisplay.displayResults(tx, `${programType}.transfer-ownership`);
 
     cmdLogger.info(
       {

--- a/src/commands/spl-token/approve.ts
+++ b/src/commands/spl-token/approve.ts
@@ -2,7 +2,7 @@ import type { TransactionOptions } from '../../types/index.js';
 import { ApproveArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { createChildLogger, logger } from '../../utils/logger.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import type { CommandContext, ApproveOptions } from '../../types/command.js';
 import { InstructionBuilder } from '../../programs/spl-token/instructions.js';
@@ -117,15 +117,14 @@ export async function approveCommand(
 
     // Build the complete transaction
     console.log('🔄 Building and simulating transaction...');
-    const transaction = await transactionBuilder.buildSingleInstructionTransaction(
-      instruction,
-      validatedArgs.authority,
-      'approve'
-    );
+    const transaction = await finalizeTransaction({
+      txBuilder: transactionBuilder,
+      instructions: [instruction],
+      payer: validatedArgs.authority,
+      instructionName: 'approve',
+      command,
+    });
     console.log('   ✅ Transaction simulation completed');
-
-    // Display results
-    TransactionDisplay.displayResults(transaction, 'approve');
 
     cmdLogger.info(
       {

--- a/src/commands/spl-token/create-mint.ts
+++ b/src/commands/spl-token/create-mint.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { Connection, PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { validateArgs } from '../../utils/validation.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { CreateMintArgsSchema } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
 import {
@@ -87,10 +87,10 @@ export async function createMintCommand(options: Record<string, string>, command
 
   if (parsed.data.withMetaplex) {
     // Create mint with Metaplex metadata
-    await createMintWithMetaplex(parsed.data, rpcUrl);
+    await createMintWithMetaplex(parsed.data, rpcUrl, command);
   } else {
     // Create plain mint without metadata
-    await createPlainMint(parsed.data, connection, rpcUrl);
+    await createPlainMint(parsed.data, connection, rpcUrl, command);
   }
 }
 
@@ -152,7 +152,11 @@ async function validateCreateMintParameters(params: CreateMintParams): Promise<v
 /**
  * Create a mint with Metaplex metadata using UMI
  */
-async function createMintWithMetaplex(params: CreateMintParams, rpcUrl: string): Promise<void> {
+async function createMintWithMetaplex(
+  params: CreateMintParams,
+  rpcUrl: string,
+  command: Command
+): Promise<void> {
   try {
     logger.info('🎨 Creating mint with Metaplex metadata...');
 
@@ -259,18 +263,17 @@ async function createMintWithMetaplex(params: CreateMintParams, rpcUrl: string):
     const tb = new TransactionBuilder({ rpcUrl });
     logger.info('🔄 Building and simulating transaction...');
 
-    const tx = await tb.buildTransaction(
-      instructions,
-      params.authority,
-      'spl-token.create_mint_with_metaplex'
-    );
-
-    logger.info('✅ Transaction simulation completed');
-
-    // Display metadata info
     logger.info(`📋 Metadata PDA: ${metadataPda}`);
 
-    TransactionDisplay.displayResults(tx, 'spl-token.create_mint_with_metaplex');
+    await finalizeTransaction({
+      txBuilder: tb,
+      instructions,
+      payer: params.authority,
+      instructionName: 'spl-token.create_mint_with_metaplex',
+      command,
+    });
+
+    logger.info('✅ Transaction simulation completed');
   } catch (error) {
     logger.error('❌ Failed to create mint with Metaplex metadata');
     logger.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -289,7 +292,8 @@ async function createMintWithMetaplex(params: CreateMintParams, rpcUrl: string):
 async function createPlainMint(
   params: CreateMintParams,
   connection: Connection,
-  rpcUrl: string
+  rpcUrl: string,
+  command: Command
 ): Promise<void> {
   try {
     logger.info('🪙 Creating plain mint (no metadata)...');
@@ -366,10 +370,15 @@ async function createPlainMint(
     const tb = new TransactionBuilder({ rpcUrl });
     logger.info('🔄 Building and simulating transaction...');
 
-    const tx = await tb.buildTransaction(instructions, params.authority, 'spl-token.create_mint');
+    await finalizeTransaction({
+      txBuilder: tb,
+      instructions,
+      payer: params.authority,
+      instructionName: 'spl-token.create_mint',
+      command,
+    });
 
     logger.info('✅ Transaction simulation completed');
-    TransactionDisplay.displayResults(tx, 'spl-token.create_mint');
   } catch (error) {
     logger.error('❌ Failed to create plain mint');
     logger.error(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/commands/spl-token/index.ts
+++ b/src/commands/spl-token/index.ts
@@ -5,6 +5,7 @@ import { transferMintAuthorityCommand } from './transfer-mint-authority.js';
 import { updateMetadataAuthorityCommand } from './update-metadata-authority.js';
 import { createMintCommand } from './create-mint.js';
 import { approveCommand } from './approve.js';
+import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 export function createSplTokenCommands(): Command {
   const splToken = new Command('spl-token')
@@ -61,6 +62,7 @@ export function createSplTokenCommands(): Command {
         process.exit(1);
       }
       const options = thisCommand.opts();
+      applyExecuteAuthority(thisCommand, options, globalOpts);
       const instr = options.instruction as string;
       if (instr === 'create-mint') {
         if (!options.authority || options.decimals === undefined) {

--- a/src/commands/spl-token/mint.ts
+++ b/src/commands/spl-token/mint.ts
@@ -5,7 +5,7 @@ import { detectTokenProgramId } from '../../utils/token.js';
 import { SplMintArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { logger } from '../../utils/logger.js';
 import { InstructionBuilder as SplInstructionBuilder } from '../../programs/spl-token/instructions.js';
 
@@ -91,9 +91,14 @@ export async function mintCommand(options: Record<string, string>, command: Comm
 
     const tb = new TransactionBuilder({ rpcUrl });
     logger.info('🔄 Building and simulating transaction...');
-    const tx = await tb.buildTransaction(ixs, authority, 'spl.mint');
+    await finalizeTransaction({
+      txBuilder: tb,
+      instructions: ixs,
+      payer: authority,
+      instructionName: 'spl.mint',
+      command,
+    });
     logger.info('✅ Transaction simulation completed');
-    TransactionDisplay.displayResults(tx, 'spl.mint');
   } catch (error) {
     logger.error('❌ Failed to mint tokens');
     logger.error(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/commands/spl-token/multisig-create.ts
+++ b/src/commands/spl-token/multisig-create.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { Connection, TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { validateArgs } from '../../utils/validation.js';
 import { logger } from '../../utils/logger.js';
 import { InstructionBuilder as SplInstructionBuilder } from '../../programs/spl-token/instructions.js';
@@ -58,13 +58,18 @@ export async function createSplMultisigCommand(options: Record<string, string>, 
     const ixs: TransactionInstruction[] = instructions;
     const tb = new TransactionBuilder({ rpcUrl });
     logger.info('🔄 Building and simulating transaction...');
-    const tx = await tb.buildTransaction(ixs, authority, 'spl.create_multisig');
-    logger.info('✅ Transaction simulation completed');
     console.log(`📮 Derived SPL Token Multisig Address: ${multisigAddress.toBase58()}`);
     console.log(
       `💡 Address derived from: authority + sha256("${seed}" + mint).hex().slice(0,32) + tokenProgram`
     );
-    TransactionDisplay.displayResults(tx, 'spl.create_multisig');
+    await finalizeTransaction({
+      txBuilder: tb,
+      instructions: ixs,
+      payer: authority,
+      instructionName: 'spl.create_multisig',
+      command,
+    });
+    logger.info('✅ Transaction simulation completed');
   } catch (error) {
     logger.error('❌ Failed to create SPL Token multisig');
     logger.error(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/commands/spl-token/transfer-mint-authority.ts
+++ b/src/commands/spl-token/transfer-mint-authority.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { Connection, TransactionInstruction } from '@solana/web3.js';
 import { validateArgs } from '../../utils/validation.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { detectTokenProgramId } from '../../utils/token.js';
 import { InstructionBuilder as SplInstructionBuilder } from '../../programs/spl-token/instructions.js';
 import { SplTransferMintAuthorityArgsSchema } from '../../types/index.js';
@@ -47,9 +47,14 @@ export async function transferMintAuthorityCommand(
 
     const tb = new TransactionBuilder({ rpcUrl });
     logger.info('🔄 Building and simulating transaction...');
-    const tx = await tb.buildTransaction(ixs, authority, 'spl.transfer_mint_authority');
+    await finalizeTransaction({
+      txBuilder: tb,
+      instructions: ixs,
+      payer: authority,
+      instructionName: 'spl.transfer_mint_authority',
+      command,
+    });
     logger.info('✅ Transaction simulation completed');
-    TransactionDisplay.displayResults(tx, 'spl.transfer_mint_authority');
   } catch (error) {
     logger.error('❌ Failed to transfer mint authority');
     logger.error(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/commands/spl-token/update-metadata-authority.ts
+++ b/src/commands/spl-token/update-metadata-authority.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { Connection, TransactionInstruction } from '@solana/web3.js';
 import { validateArgs } from '../../utils/validation.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
-import { TransactionDisplay } from '../../utils/display.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { detectTokenProgramId } from '../../utils/token.js';
 import { InstructionBuilder as SplInstructionBuilder } from '../../programs/spl-token/instructions.js';
 import { SplUpdateMetadataAuthorityArgsSchema } from '../../types/index.js';
@@ -47,13 +47,14 @@ export async function updateMetadataAuthorityCommand(
 
     const tb = new TransactionBuilder({ rpcUrl });
     logger.info('🔄 Building and simulating transaction...');
-    const tx = await tb.buildTransaction(
-      ixs,
-      parsed.data.authority,
-      'spl.update_metadata_authority'
-    );
+    await finalizeTransaction({
+      txBuilder: tb,
+      instructions: ixs,
+      payer: parsed.data.authority,
+      instructionName: 'spl.update_metadata_authority',
+      command,
+    });
     logger.info('✅ Transaction simulation completed');
-    TransactionDisplay.displayResults(tx, 'spl.update_metadata_authority');
   } catch (error) {
     logger.error('❌ Failed to update metadata authority');
     logger.error(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/commands/utils/index.ts
+++ b/src/commands/utils/index.ts
@@ -54,6 +54,13 @@ Available Program Types:
   • Use --remote-chain-selector to also derive chain-specific config accounts
 `
     )
+    .hook('preAction', thisCommand => {
+      const globalOpts = thisCommand.parent?.opts() || {};
+      if (globalOpts.execute) {
+        console.error('❌ --execute is not supported for utility commands');
+        process.exit(1);
+      }
+    })
     .action((options, command) => {
       // Route to the appropriate utility handler
       if (options.instruction === 'derive-accounts') {

--- a/src/core/transaction-builder.ts
+++ b/src/core/transaction-builder.ts
@@ -121,6 +121,10 @@ export class TransactionBuilder {
           metadata: {
             generatedAt: new Date().toISOString(),
             computeUnits,
+            simulationSuccess: simulationResult.success,
+            ...(simulationResult.error !== undefined
+              ? { simulationError: simulationResult.error }
+              : {}),
           },
         };
 

--- a/src/core/transaction-builder.ts
+++ b/src/core/transaction-builder.ts
@@ -1,5 +1,6 @@
 import {
   Connection,
+  Keypair,
   TransactionInstruction,
   VersionedTransaction,
   TransactionMessage,
@@ -155,6 +156,49 @@ export class TransactionBuilder {
     instructionName?: string
   ): Promise<GeneratedTransaction> {
     return this.buildTransaction([instruction], payer, instructionName);
+  }
+
+  /**
+   * Simulate a SIGNED transaction with signature verification enabled.
+   *
+   * Used only in --execute mode: it signs a v0 message with the provided keypair and runs
+   * `simulateTransaction({ sigVerify: true })`, so a transaction that still has a required signer the
+   * local keypair did not provide fails fast and clearly instead of later at send time. This triggers
+   * only when an instruction marks a signer that is NOT our keypair — e.g. an SPL multisig whose
+   * threshold needs a co-signer we don't control, or extra signer accounts mistakenly listed in
+   * `--multisig-signers`. A 1-of-N multisig where we pass only our own member key signs fully and
+   * passes. Verifying the signer set is blockhash-independent, so fetching a fresh blockhash here is
+   * fine even though the executor fetches its own at send.
+   */
+  async simulateSignedTransaction(
+    instructions: TransactionInstruction[],
+    payer: PublicKey,
+    signer: Keypair
+  ): Promise<{ success: boolean; error?: string; logs?: string[] }> {
+    const { blockhash } = await this.connection.getLatestBlockhash();
+    const message = new TransactionMessage({
+      payerKey: payer,
+      recentBlockhash: blockhash,
+      instructions,
+    }).compileToV0Message();
+
+    const signedTx = new VersionedTransaction(message);
+    signedTx.sign([signer]);
+
+    const simulation = await this.connection.simulateTransaction(signedTx, {
+      sigVerify: true,
+      commitment: DEFAULT_TRANSACTION_CONFIG.COMMITMENT,
+    });
+
+    if (simulation.value.err) {
+      return {
+        success: false,
+        error: JSON.stringify(simulation.value.err),
+        logs: simulation.value.logs || [],
+      };
+    }
+
+    return { success: true, logs: simulation.value.logs || [] };
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,12 @@ import { Command } from 'commander';
 import { registerCommands } from './commands/index.js';
 
 import { logger } from './utils/logger.js';
-import { CLI_CONFIG, SOLANA_ENVIRONMENTS, type SolanaEnvironment } from './utils/constants.js';
+import {
+  CLI_CONFIG,
+  DEFAULT_KEYPAIR_PATH,
+  SOLANA_ENVIRONMENTS,
+  type SolanaEnvironment,
+} from './utils/constants.js';
 
 /**
  * Main CLI application entry point
@@ -24,6 +29,14 @@ async function main(): Promise<void> {
       `Solana environment (${Object.keys(SOLANA_ENVIRONMENTS).join('|')})`
     )
     .option('--rpc-url <url>', 'Custom Solana RPC URL (overrides --env if provided)')
+    .option(
+      '--execute',
+      'Sign and send the transaction with a local keypair instead of outputting Base58'
+    )
+    .option(
+      '--keypair <path>',
+      `Path to keypair file (default: ${DEFAULT_KEYPAIR_PATH} when --execute is set)`
+    )
     .hook('preAction', thisCommand => {
       const opts = thisCommand.opts();
 
@@ -65,6 +78,22 @@ async function main(): Promise<void> {
       } else if (hasEnv) {
         opts.resolvedRpcUrl = SOLANA_ENVIRONMENTS[hasEnv as SolanaEnvironment];
       }
+
+      // Execution mode validation
+      if (opts.keypair && !opts.execute) {
+        console.error('❌ --keypair can only be used with --execute');
+        process.exit(1);
+      }
+
+      if (opts.execute) {
+        if (!opts.resolvedRpcUrl) {
+          console.error('❌ --execute requires --env or --rpc-url');
+          process.exit(1);
+        }
+        if (!opts.keypair) {
+          opts.keypair = DEFAULT_KEYPAIR_PATH;
+        }
+      }
     });
 
   // Register all program-specific commands (for backwards compatibility)
@@ -84,9 +113,18 @@ async function main(): Promise<void> {
     console.log('       --mint "Token_Mint_Address" \\');
     console.log('       --authority "New_Authority_PublicKey"');
     console.log('');
+    console.log('  3. Execute directly with a local keypair (Devnet example):');
+    console.log('     $ pnpm bs58 --env devnet --execute \\');
+    console.log('       burnmint-token-pool --instruction accept-ownership \\');
+    console.log('       --program-id "Your_Program_ID" \\');
+    console.log('       --mint "Token_Mint_Address" \\');
+    console.log('       --authority "Your_EOA_PublicKey"');
+    console.log('');
     console.log('💡 Tips:');
     console.log('  • Use --verbose for detailed logging');
     console.log('  • Transaction data is Base58-encoded for Squads multisig');
+    console.log('  • Use --execute to sign and send with your local keypair');
+    console.log('  • --keypair defaults to ~/.config/solana/id.json when --execute is set');
     console.log('  • Always test on Devnet first!');
     console.log('');
   });

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -1,3 +1,5 @@
+import type { Keypair } from '@solana/web3.js';
+
 /**
  * Global CLI options available on the root Commander program
  */
@@ -8,6 +10,8 @@ export interface GlobalCommandOptions {
   resolvedRpcUrl?: string;
   execute?: boolean;
   keypair?: string;
+  /** Cached signer keypair, loaded once per invocation in --execute mode */
+  _signerKeypair?: Keypair;
 }
 
 /**

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -1,11 +1,23 @@
 /**
+ * Global CLI options available on the root Commander program
+ */
+export interface GlobalCommandOptions {
+  verbose?: boolean;
+  environment?: string;
+  rpcUrl?: string;
+  resolvedRpcUrl?: string;
+  execute?: boolean;
+  keypair?: string;
+}
+
+/**
  * Standard Commander.js command context type used across all commands
  */
 export interface CommandContext {
   parent?: {
-    parent?: { opts(): { rpcUrl?: string; verbose?: boolean; resolvedRpcUrl?: string } };
-    opts(): { rpcUrl?: string; verbose?: boolean; resolvedRpcUrl?: string };
-  };
+    parent?: { opts(): GlobalCommandOptions } | null;
+    opts(): GlobalCommandOptions;
+  } | null;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -767,6 +767,8 @@ export interface GeneratedTransaction {
   metadata: {
     generatedAt: string;
     computeUnits?: number;
+    simulationSuccess?: boolean;
+    simulationError?: string;
   };
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -13,6 +13,16 @@ export const SOLANA_ENVIRONMENTS = {
 export type SolanaEnvironment = keyof typeof SOLANA_ENVIRONMENTS;
 
 /**
+ * Well-known, fixed genesis hashes per Solana cluster. Used to authoritatively infer the cluster
+ * from any RPC connection (provider-agnostic), e.g. when only --rpc-url is given.
+ */
+export const SOLANA_GENESIS_HASHES: Record<'mainnet' | 'devnet' | 'testnet', string> = {
+  mainnet: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
+  devnet: 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG',
+  testnet: '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY',
+};
+
+/**
  * Get RPC URL for a given environment
  * @param env - Environment name (mainnet, devnet, testnet, localhost)
  * @returns RPC URL string

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import { PublicKey } from '@solana/web3.js';
 /**
  * Solana environments and their RPC endpoints
@@ -25,6 +26,11 @@ export function getRpcUrl(env: string): string {
     `Invalid environment: ${env}. Must be one of: ${Object.keys(SOLANA_ENVIRONMENTS).join(', ')}`
   );
 }
+
+/**
+ * Default Solana CLI keypair path
+ */
+export const DEFAULT_KEYPAIR_PATH = `${os.homedir()}/.config/solana/id.json`;
 
 /**
  * Default transaction configuration

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -125,6 +125,28 @@ export class TransactionDisplay {
   }
 
   /**
+   * Display a loud banner before signing & sending in --execute mode, so it is never
+   * ambiguous that a real, irreversible transaction is about to be sent and by whom.
+   */
+  static displayExecutionBanner(params: {
+    signer: string;
+    instructionName: string;
+    env?: SolanaEnvironment | undefined;
+    rpcUrl: string;
+  }): void {
+    const envLabel = params.env ?? 'custom RPC';
+    logger.info('');
+    if (params.env === 'mainnet') {
+      logger.warn('🚨🚨🚨 MAINNET EXECUTION — this is REAL and IRREVERSIBLE 🚨🚨🚨');
+    }
+    logger.info(`🖊️  EXECUTE MODE — signing & sending on ${envLabel}`);
+    logger.info(`   Signer:      ${params.signer}`);
+    logger.info(`   Instruction: ${params.instructionName}`);
+    logger.info(`   RPC:         ${params.rpcUrl}`);
+    logger.info('');
+  }
+
+  /**
    * Display on-chain execution results (no Base58 output)
    */
   static displayExecutionResults(
@@ -132,17 +154,22 @@ export class TransactionDisplay {
     instructionName: string,
     env?: SolanaEnvironment
   ): void {
-    const explorerUrl = env
-      ? getTransactionExplorerUrl(signature, env)
-      : `https://explorer.solana.com/tx/${signature}`;
-
     logger.info('');
     logger.info('🎉 Transaction executed successfully!');
     logger.info('');
     logger.info('📋 Execution Details:');
     logger.info(`   Instruction: ${instructionName}`);
     logger.info(`   Signature:   ${signature}`);
-    logger.info(`   Explorer:    ${explorerUrl}`);
+    if (env) {
+      // Known cluster → clean explorer link (no RPC URL embedded, so no API-key leakage).
+      logger.info(`   Explorer:    ${getTransactionExplorerUrl(signature, env)}`);
+    } else {
+      // Custom/local RPC — the public explorer can't reliably reach it, and we must not embed the
+      // (possibly secret-bearing) RPC URL. Surface the signature for the user to look up themselves.
+      logger.info(
+        '   Explorer:    custom/local RPC — look up the signature above in your explorer'
+      );
+    }
     logger.info('');
   }
 

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -1,5 +1,7 @@
 import type { GeneratedTransaction } from '../types/index.js';
 import { logger } from './logger.js';
+import { getTransactionExplorerUrl } from './explorer.js';
+import type { SolanaEnvironment } from './constants.js';
 
 /**
  * Utility for displaying transaction data with beautiful formatting
@@ -119,6 +121,28 @@ export class TransactionDisplay {
     }
 
     logger.info('   • This transaction is valid until the blockhash expires (~2 minutes)');
+    logger.info('');
+  }
+
+  /**
+   * Display on-chain execution results (no Base58 output)
+   */
+  static displayExecutionResults(
+    signature: string,
+    instructionName: string,
+    env?: SolanaEnvironment
+  ): void {
+    const explorerUrl = env
+      ? getTransactionExplorerUrl(signature, env)
+      : `https://explorer.solana.com/tx/${signature}`;
+
+    logger.info('');
+    logger.info('🎉 Transaction executed successfully!');
+    logger.info('');
+    logger.info('📋 Execution Details:');
+    logger.info(`   Instruction: ${instructionName}`);
+    logger.info(`   Signature:   ${signature}`);
+    logger.info(`   Explorer:    ${explorerUrl}`);
     logger.info('');
   }
 

--- a/src/utils/explorer.ts
+++ b/src/utils/explorer.ts
@@ -1,6 +1,24 @@
-import type { SolanaEnvironment } from './constants.js';
+import type { Connection } from '@solana/web3.js';
+import { SOLANA_GENESIS_HASHES, type SolanaEnvironment } from './constants.js';
 
 const SOLANA_EXPLORER_BASE_URL = 'https://explorer.solana.com';
+
+/**
+ * Authoritatively infer the cluster from an RPC connection via its genesis hash. This is
+ * provider-agnostic (works for private RPCs like Helius/Alchemy/QuickNode) and never inspects the
+ * RPC URL, so it cannot leak API keys embedded in the URL.
+ *
+ * @returns the matching cluster, or `undefined` for localhost / unknown custom validators.
+ */
+export async function resolveClusterByGenesisHash(
+  connection: Connection
+): Promise<SolanaEnvironment | undefined> {
+  const hash = await connection.getGenesisHash();
+  const match = (
+    Object.keys(SOLANA_GENESIS_HASHES) as Array<keyof typeof SOLANA_GENESIS_HASHES>
+  ).find(env => SOLANA_GENESIS_HASHES[env] === hash);
+  return match;
+}
 
 function getClusterQuery(env: SolanaEnvironment): string {
   if (env === 'mainnet') {

--- a/src/utils/finalize-transaction.ts
+++ b/src/utils/finalize-transaction.ts
@@ -3,18 +3,13 @@ import { TransactionBuilder } from '../core/transaction-builder.js';
 import type { CommandContext } from '../types/command.js';
 import type { GeneratedTransaction } from '../types/index.js';
 import { TransactionDisplay } from './display.js';
-import { loadKeypair, executeTransaction } from './transaction-executor.js';
+import { executeTransaction } from './transaction-executor.js';
+import { loadSignerKeypair } from './keypair.js';
+import { resolveClusterByGenesisHash } from './explorer.js';
 import type { SolanaEnvironment } from './constants.js';
 
 function getGlobalOptions(command: CommandContext) {
   return command.parent?.parent?.opts() || command.parent?.opts() || {};
-}
-
-function expandHomePath(path: string): string {
-  if (path.startsWith('~/')) {
-    return `${process.env.HOME || process.env.USERPROFILE || ''}/${path.slice(2)}`;
-  }
-  return path;
 }
 
 /**
@@ -37,8 +32,7 @@ export async function finalizeTransaction(opts: {
     return tx;
   }
 
-  const keypairPath = expandHomePath(globalOptions.keypair!);
-  const keypair = loadKeypair(keypairPath);
+  const keypair = loadSignerKeypair(globalOptions);
 
   if (!keypair.publicKey.equals(payer)) {
     throw new Error(
@@ -51,11 +45,44 @@ export async function finalizeTransaction(opts: {
     throw new Error(`Transaction simulation failed${simError}`);
   }
 
+  // Verify the local keypair can satisfy ALL required signatures before announcing/sending.
+  // The build-time simulation above runs unsigned (sigVerify:false) for the Squads path, so it
+  // cannot catch a transaction that still requires a signature we don't hold. Re-simulate the signed
+  // transaction with sigVerify enabled to fail fast on that case.
+  const signedSim = await txBuilder.simulateSignedTransaction(instructions, payer, keypair);
+  if (!signedSim.success) {
+    throw new Error(
+      'Signature verification failed in simulation. In --execute mode only your keypair signs, but ' +
+        'this transaction still requires another signature. For an SPL multisig, pass only key(s) ' +
+        'you hold in --multisig-signers (a 1-of-N multisig needs just your own member key); if the ' +
+        "threshold requires co-signers you don't control, it can't be executed locally — use Squads " +
+        `mode (omit --execute). Details: ${signedSim.error}`
+    );
+  }
+
   const rpcUrl = globalOptions.resolvedRpcUrl!;
   const connection = new Connection(rpcUrl);
+
+  // Resolve the cluster authoritatively from the chain's genesis hash when --env was not given, so
+  // both the mainnet warning and the explorer link are correct even with --rpc-url. Never throw here.
+  let env = globalOptions.environment as SolanaEnvironment | undefined;
+  if (!env) {
+    try {
+      env = await resolveClusterByGenesisHash(connection);
+    } catch {
+      // leave undefined — a missing cluster only degrades the explorer link, not execution
+    }
+  }
+
+  TransactionDisplay.displayExecutionBanner({
+    signer: keypair.publicKey.toBase58(),
+    instructionName,
+    env,
+    rpcUrl,
+  });
+
   const signature = await executeTransaction(connection, instructions, [keypair]);
 
-  const env = globalOptions.environment as SolanaEnvironment | undefined;
   TransactionDisplay.displayExecutionResults(signature, instructionName, env);
   return tx;
 }

--- a/src/utils/finalize-transaction.ts
+++ b/src/utils/finalize-transaction.ts
@@ -1,0 +1,61 @@
+import { Connection, PublicKey, TransactionInstruction } from '@solana/web3.js';
+import { TransactionBuilder } from '../core/transaction-builder.js';
+import type { CommandContext } from '../types/command.js';
+import type { GeneratedTransaction } from '../types/index.js';
+import { TransactionDisplay } from './display.js';
+import { loadKeypair, executeTransaction } from './transaction-executor.js';
+import type { SolanaEnvironment } from './constants.js';
+
+function getGlobalOptions(command: CommandContext) {
+  return command.parent?.parent?.opts() || command.parent?.opts() || {};
+}
+
+function expandHomePath(path: string): string {
+  if (path.startsWith('~/')) {
+    return `${process.env.HOME || process.env.USERPROFILE || ''}/${path.slice(2)}`;
+  }
+  return path;
+}
+
+/**
+ * Build and either display Base58 transaction data or execute on-chain with a local keypair.
+ */
+export async function finalizeTransaction(opts: {
+  txBuilder: TransactionBuilder;
+  instructions: TransactionInstruction[];
+  payer: PublicKey;
+  instructionName: string;
+  command: CommandContext;
+}): Promise<GeneratedTransaction> {
+  const { txBuilder, instructions, payer, instructionName, command } = opts;
+  const globalOptions = getGlobalOptions(command);
+
+  const tx = await txBuilder.buildTransaction(instructions, payer, instructionName);
+
+  if (!globalOptions.execute) {
+    TransactionDisplay.displayResults(tx, instructionName);
+    return tx;
+  }
+
+  const keypairPath = expandHomePath(globalOptions.keypair!);
+  const keypair = loadKeypair(keypairPath);
+
+  if (!keypair.publicKey.equals(payer)) {
+    throw new Error(
+      'Keypair does not match --authority; EOA execution requires your keypair to be the transaction fee payer and signer.'
+    );
+  }
+
+  if (tx.metadata.simulationSuccess === false) {
+    const simError = tx.metadata.simulationError ? `: ${tx.metadata.simulationError}` : '';
+    throw new Error(`Transaction simulation failed${simError}`);
+  }
+
+  const rpcUrl = globalOptions.resolvedRpcUrl!;
+  const connection = new Connection(rpcUrl);
+  const signature = await executeTransaction(connection, instructions, [keypair]);
+
+  const env = globalOptions.environment as SolanaEnvironment | undefined;
+  TransactionDisplay.displayExecutionResults(signature, instructionName, env);
+  return tx;
+}

--- a/src/utils/keypair.ts
+++ b/src/utils/keypair.ts
@@ -1,0 +1,87 @@
+import type { Command } from 'commander';
+import { Keypair } from '@solana/web3.js';
+import { loadKeypair } from './transaction-executor.js';
+import { DEFAULT_KEYPAIR_PATH } from './constants.js';
+import type { GlobalCommandOptions } from '../types/command.js';
+
+/**
+ * Expand a leading `~/` to the user's home directory.
+ */
+export function expandHomePath(path: string): string {
+  if (path.startsWith('~/')) {
+    return `${process.env.HOME || process.env.USERPROFILE || ''}/${path.slice(2)}`;
+  }
+  return path;
+}
+
+/**
+ * Resolve the keypair path to load for --execute mode.
+ * Uses --keypair when provided, otherwise the default Solana CLI keypair.
+ */
+export function resolveKeypairPath(globalOpts: GlobalCommandOptions): string {
+  return expandHomePath(globalOpts.keypair ?? DEFAULT_KEYPAIR_PATH);
+}
+
+/**
+ * Load the signer keypair for --execute mode, caching it on the global options
+ * object so it is only read from disk once per invocation. Prints a friendly
+ * message and exits if the file cannot be loaded.
+ */
+export function loadSignerKeypair(globalOpts: GlobalCommandOptions): Keypair {
+  if (globalOpts._signerKeypair) {
+    return globalOpts._signerKeypair;
+  }
+
+  const keypairPath = resolveKeypairPath(globalOpts);
+  try {
+    const keypair = loadKeypair(keypairPath);
+    globalOpts._signerKeypair = keypair;
+    return keypair;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`❌ Could not load keypair: ${message}`);
+    console.error(
+      '💡 Pass --keypair <path>, or run `solana-keygen new` to create the default one.'
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * In --execute mode, auto-derive --authority from the signer keypair so the user
+ * does not have to retype their own public key.
+ *
+ * - No-op when --execute is not set (encode/Squads mode keeps --authority required).
+ * - When --authority is omitted, sets it to the keypair's public key.
+ * - When --authority is provided, enforces that it matches the keypair.
+ *
+ * Sets the value on both the live `options` object (so the hook's own validation
+ * sees it) and via `setOptionValue` (so the action handler sees it).
+ */
+export function applyExecuteAuthority(
+  thisCommand: Command,
+  options: Record<string, unknown>,
+  globalOpts: GlobalCommandOptions
+): void {
+  if (!globalOpts.execute) {
+    return;
+  }
+
+  const signer = loadSignerKeypair(globalOpts).publicKey.toBase58();
+  const provided = options.authority as string | undefined;
+
+  if (!provided) {
+    options.authority = signer;
+    thisCommand.setOptionValue('authority', signer);
+    console.log(`🔑 Authority derived from keypair: ${signer}`);
+    return;
+  }
+
+  if (provided !== signer) {
+    console.error(`❌ --authority ${provided} does not match keypair ${signer}`);
+    console.error(
+      '💡 In --execute mode, omit --authority (it defaults to your keypair) or pass a matching one.'
+    );
+    process.exit(1);
+  }
+}

--- a/src/utils/transaction-executor.ts
+++ b/src/utils/transaction-executor.ts
@@ -35,7 +35,12 @@ export function loadKeypair(path: string): Keypair {
  * Execute a set of instructions as a single transaction
  *
  * Uses 'finalized' commitment for blockhash to reduce expiration issues on slow/congested RPCs.
- * Implements automatic retry logic for transient RPC failures.
+ *
+ * The transaction is built and signed exactly ONCE, before the retry loop. Retries only
+ * re-broadcast that same signed transaction — because the signature is identical, the network
+ * de-duplicates it, so a retry (e.g. after a confirmation timeout where the first send already
+ * landed) can never execute the instructions twice. Re-signing with a fresh blockhash would create
+ * a new signature and risk double execution (e.g. a double mint), which is exactly what we avoid.
  *
  * @param connection - Solana RPC connection
  * @param instructions - Transaction instructions to execute
@@ -67,30 +72,28 @@ export async function executeTransaction(
     'Preparing to execute transaction'
   );
 
+  // Build and sign ONCE so every retry re-broadcasts an identical signature (see note above).
+  // Use 'finalized' commitment for a more reliable blockhash on slow RPCs.
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('finalized');
+  logger.debug({ blockhash, lastValidBlockHeight }, 'Building and signing transaction');
+
+  const tx = new Transaction();
+  tx.recentBlockhash = blockhash;
+  tx.lastValidBlockHeight = lastValidBlockHeight;
+  tx.feePayer = feePayer.publicKey;
+  tx.add(...instructions);
+  tx.sign(...signers);
+  const rawTransaction = tx.serialize();
+
   const maxRetries = 3;
   let lastError: Error | null = null;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      logger.debug({ attempt, maxRetries }, 'Fetching latest blockhash');
+      logger.debug({ attempt, maxRetries }, 'Sending signed transaction');
 
-      // Use 'finalized' commitment for more reliable blockhash on slow RPCs
-      const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('finalized');
-
-      logger.debug({ blockhash, lastValidBlockHeight }, 'Building transaction');
-
-      // Build and sign transaction
-      const tx = new Transaction();
-      tx.recentBlockhash = blockhash;
-      tx.lastValidBlockHeight = lastValidBlockHeight;
-      tx.feePayer = feePayer.publicKey;
-      tx.add(...instructions);
-      tx.sign(...signers);
-
-      logger.debug({ attempt }, 'Sending signed transaction');
-
-      // Send with preflight checks and retries
-      const rawTransaction = tx.serialize();
+      // Re-broadcasting the same signed transaction is idempotent (identical signature), so a retry
+      // after a confirmation timeout cannot double-execute the instructions.
       const signature = await connection.sendRawTransaction(rawTransaction, {
         skipPreflight: false,
         maxRetries: 2,


### PR DESCRIPTION
Allow signing and sending transactions locally with a keypair while preserving Base58 generation for multisig workflows. Reject non-empty pool addresses on init-chain-remote-config to match on-chain constraints.