### PR TITLE
Fix/eoa execute review

### DIFF
--- a/src/commands/burnmint/index.ts
+++ b/src/commands/burnmint/index.ts
@@ -12,6 +12,7 @@ import { appendRemotePoolAddressesCommand } from './append-remote-pool-addresses
 import { deleteChainConfigCommand } from './delete-chain-config.js';
 import { configureAllowListCommand } from './configure-allow-list.js';
 import { removeFromAllowListCommand } from './remove-from-allow-list.js';
+import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 /**
  * Burnmint Token Pool commands
@@ -126,6 +127,7 @@ export function createBurnmintCommands(): Command {
         console.error('❌ --execute is not supported for read-only instructions');
         process.exit(1);
       }
+      applyExecuteAuthority(thisCommand, options, globalOpts);
       if (!readOnlyInstructions.includes(options.instruction) && !options.authority) {
         console.error('❌ This instruction requires: --authority');
         console.error(

--- a/src/commands/lockrelease/index.ts
+++ b/src/commands/lockrelease/index.ts
@@ -16,6 +16,7 @@ import { provideLiquidityCommand } from './provide-liquidity.js';
 import { withdrawLiquidityCommand } from './withdraw-liquidity.js';
 import { setRebalancerCommand } from './set-rebalancer.js';
 import { setCanAcceptLiquidityCommand } from './set-can-accept-liquidity.js';
+import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 /**
  * Lock/Release Token Pool commands
@@ -149,6 +150,7 @@ export function createLockReleaseCommands(): Command {
         console.error('❌ --execute is not supported for read-only instructions');
         process.exit(1);
       }
+      applyExecuteAuthority(thisCommand, options, globalOpts);
       if (!readOnlyInstructions.includes(options.instruction) && !options.authority) {
         console.error('❌ This instruction requires: --authority');
         console.error(

--- a/src/commands/metaplex/index.ts
+++ b/src/commands/metaplex/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { updateMetadataAuthorityCommand } from './update-authority.js';
+import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 export function createMetaplexCommands(): Command {
   const metaplex = new Command('metaplex')
@@ -17,6 +18,7 @@ export function createMetaplexCommands(): Command {
         process.exit(1);
       }
       const options = thisCommand.opts();
+      applyExecuteAuthority(thisCommand, options, globalOpts);
       const instr = options.instruction as string;
       if (instr === 'update-authority') {
         if (!options.authority || !options.mint || !options.newAuthority) {

--- a/src/commands/router/create-lookup-table.ts
+++ b/src/commands/router/create-lookup-table.ts
@@ -53,22 +53,28 @@ export async function createLookupTableCommand(options: Record<string, string>, 
     });
 
     console.log(`📮 Derived Lookup Table Address: ${lookupTableAddress.toBase58()}`);
-    console.log('   ✅ Transaction simulation completed');
-    console.log('');
-    console.log('⚠️  ALT CREATION TIMING CONSTRAINT');
-    console.log('   This transaction must be imported AND executed within 60-90 seconds');
-    console.log('   due to slot-dependent address derivation.');
-    console.log('');
-    console.log('💡 RECOMMENDED: Use the companion tool for immediate execution:');
-    console.log(
-      `   pnpm create-alt --keypair <EOA_KEYPAIR> --authority ${parsed.data.authority.toBase58()} \\`
-    );
-    console.log(`     --program-id ${parsed.data.programId.toBase58()} \\`);
-    console.log(`     --fee-quoter-program-id ${parsed.data.feeQuoterProgramId.toBase58()} \\`);
-    console.log(`     --pool-program-id ${parsed.data.poolProgramId.toBase58()} \\`);
-    console.log(`     --mint ${parsed.data.mint.toBase58()} \\`);
-    console.log(`     --env ${globalOptions.environment || 'mainnet'}`);
-    console.log('');
+
+    // The slot-expiry timing constraint only applies to the Base58 → Squads flow, where a human
+    // imports and executes the transaction later. In --execute mode the EOA signs immediately, so
+    // there is no race and the companion tool is not needed.
+    if (!globalOptions.execute) {
+      console.log('   ✅ Transaction simulation completed');
+      console.log('');
+      console.log('⚠️  ALT CREATION TIMING CONSTRAINT');
+      console.log('   This transaction must be imported AND executed within 60-90 seconds');
+      console.log('   due to slot-dependent address derivation.');
+      console.log('');
+      console.log('💡 RECOMMENDED: Use the companion tool for immediate execution:');
+      console.log(
+        `   pnpm create-alt --keypair <EOA_KEYPAIR> --authority ${parsed.data.authority.toBase58()} \\`
+      );
+      console.log(`     --program-id ${parsed.data.programId.toBase58()} \\`);
+      console.log(`     --fee-quoter-program-id ${parsed.data.feeQuoterProgramId.toBase58()} \\`);
+      console.log(`     --pool-program-id ${parsed.data.poolProgramId.toBase58()} \\`);
+      console.log(`     --mint ${parsed.data.mint.toBase58()} \\`);
+      console.log(`     --env ${globalOptions.environment || 'mainnet'}`);
+      console.log('');
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (error instanceof Error && error.stack) {

--- a/src/commands/router/index.ts
+++ b/src/commands/router/index.ts
@@ -6,6 +6,7 @@ import { transferAdminRoleCommand } from './transfer-admin-role.js';
 import { setPoolCommand } from './set-pool.js';
 import { createLookupTableCommand } from './create-lookup-table.js';
 import { appendToLookupTableCommand } from './append-to-lookup-table.js';
+import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 /**
  * CCIP Router commands
@@ -60,6 +61,7 @@ export function createRouterCommands(): Command {
       }
 
       const options = thisCommand.opts();
+      applyExecuteAuthority(thisCommand, options, globalOpts);
 
       // common - append-to-lookup-table doesn't need program-id
       const instr = options.instruction as string;

--- a/src/commands/spl-token/index.ts
+++ b/src/commands/spl-token/index.ts
@@ -5,6 +5,7 @@ import { transferMintAuthorityCommand } from './transfer-mint-authority.js';
 import { updateMetadataAuthorityCommand } from './update-metadata-authority.js';
 import { createMintCommand } from './create-mint.js';
 import { approveCommand } from './approve.js';
+import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 export function createSplTokenCommands(): Command {
   const splToken = new Command('spl-token')
@@ -61,6 +62,7 @@ export function createSplTokenCommands(): Command {
         process.exit(1);
       }
       const options = thisCommand.opts();
+      applyExecuteAuthority(thisCommand, options, globalOpts);
       const instr = options.instruction as string;
       if (instr === 'create-mint') {
         if (!options.authority || options.decimals === undefined) {

--- a/src/core/transaction-builder.ts
+++ b/src/core/transaction-builder.ts
@@ -1,5 +1,6 @@
 import {
   Connection,
+  Keypair,
   TransactionInstruction,
   VersionedTransaction,
   TransactionMessage,
@@ -155,6 +156,49 @@ export class TransactionBuilder {
     instructionName?: string
   ): Promise<GeneratedTransaction> {
     return this.buildTransaction([instruction], payer, instructionName);
+  }
+
+  /**
+   * Simulate a SIGNED transaction with signature verification enabled.
+   *
+   * Used only in --execute mode: it signs a v0 message with the provided keypair and runs
+   * `simulateTransaction({ sigVerify: true })`, so a transaction that still has a required signer the
+   * local keypair did not provide fails fast and clearly instead of later at send time. This triggers
+   * only when an instruction marks a signer that is NOT our keypair — e.g. an SPL multisig whose
+   * threshold needs a co-signer we don't control, or extra signer accounts mistakenly listed in
+   * `--multisig-signers`. A 1-of-N multisig where we pass only our own member key signs fully and
+   * passes. Verifying the signer set is blockhash-independent, so fetching a fresh blockhash here is
+   * fine even though the executor fetches its own at send.
+   */
+  async simulateSignedTransaction(
+    instructions: TransactionInstruction[],
+    payer: PublicKey,
+    signer: Keypair
+  ): Promise<{ success: boolean; error?: string; logs?: string[] }> {
+    const { blockhash } = await this.connection.getLatestBlockhash();
+    const message = new TransactionMessage({
+      payerKey: payer,
+      recentBlockhash: blockhash,
+      instructions,
+    }).compileToV0Message();
+
+    const signedTx = new VersionedTransaction(message);
+    signedTx.sign([signer]);
+
+    const simulation = await this.connection.simulateTransaction(signedTx, {
+      sigVerify: true,
+      commitment: DEFAULT_TRANSACTION_CONFIG.COMMITMENT,
+    });
+
+    if (simulation.value.err) {
+      return {
+        success: false,
+        error: JSON.stringify(simulation.value.err),
+        logs: simulation.value.logs || [],
+      };
+    }
+
+    return { success: true, logs: simulation.value.logs || [] };
   }
 
   /**

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -1,3 +1,5 @@
+import type { Keypair } from '@solana/web3.js';
+
 /**
  * Global CLI options available on the root Commander program
  */
@@ -8,6 +10,8 @@ export interface GlobalCommandOptions {
   resolvedRpcUrl?: string;
   execute?: boolean;
   keypair?: string;
+  /** Cached signer keypair, loaded once per invocation in --execute mode */
+  _signerKeypair?: Keypair;
 }
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -13,6 +13,16 @@ export const SOLANA_ENVIRONMENTS = {
 export type SolanaEnvironment = keyof typeof SOLANA_ENVIRONMENTS;
 
 /**
+ * Well-known, fixed genesis hashes per Solana cluster. Used to authoritatively infer the cluster
+ * from any RPC connection (provider-agnostic), e.g. when only --rpc-url is given.
+ */
+export const SOLANA_GENESIS_HASHES: Record<'mainnet' | 'devnet' | 'testnet', string> = {
+  mainnet: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
+  devnet: 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG',
+  testnet: '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY',
+};
+
+/**
  * Get RPC URL for a given environment
  * @param env - Environment name (mainnet, devnet, testnet, localhost)
  * @returns RPC URL string

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -125,6 +125,28 @@ export class TransactionDisplay {
   }
 
   /**
+   * Display a loud banner before signing & sending in --execute mode, so it is never
+   * ambiguous that a real, irreversible transaction is about to be sent and by whom.
+   */
+  static displayExecutionBanner(params: {
+    signer: string;
+    instructionName: string;
+    env?: SolanaEnvironment | undefined;
+    rpcUrl: string;
+  }): void {
+    const envLabel = params.env ?? 'custom RPC';
+    logger.info('');
+    if (params.env === 'mainnet') {
+      logger.warn('🚨🚨🚨 MAINNET EXECUTION — this is REAL and IRREVERSIBLE 🚨🚨🚨');
+    }
+    logger.info(`🖊️  EXECUTE MODE — signing & sending on ${envLabel}`);
+    logger.info(`   Signer:      ${params.signer}`);
+    logger.info(`   Instruction: ${params.instructionName}`);
+    logger.info(`   RPC:         ${params.rpcUrl}`);
+    logger.info('');
+  }
+
+  /**
    * Display on-chain execution results (no Base58 output)
    */
   static displayExecutionResults(
@@ -132,17 +154,22 @@ export class TransactionDisplay {
     instructionName: string,
     env?: SolanaEnvironment
   ): void {
-    const explorerUrl = env
-      ? getTransactionExplorerUrl(signature, env)
-      : `https://explorer.solana.com/tx/${signature}`;
-
     logger.info('');
     logger.info('🎉 Transaction executed successfully!');
     logger.info('');
     logger.info('📋 Execution Details:');
     logger.info(`   Instruction: ${instructionName}`);
     logger.info(`   Signature:   ${signature}`);
-    logger.info(`   Explorer:    ${explorerUrl}`);
+    if (env) {
+      // Known cluster → clean explorer link (no RPC URL embedded, so no API-key leakage).
+      logger.info(`   Explorer:    ${getTransactionExplorerUrl(signature, env)}`);
+    } else {
+      // Custom/local RPC — the public explorer can't reliably reach it, and we must not embed the
+      // (possibly secret-bearing) RPC URL. Surface the signature for the user to look up themselves.
+      logger.info(
+        '   Explorer:    custom/local RPC — look up the signature above in your explorer'
+      );
+    }
     logger.info('');
   }
 

--- a/src/utils/explorer.ts
+++ b/src/utils/explorer.ts
@@ -1,6 +1,24 @@
-import type { SolanaEnvironment } from './constants.js';
+import type { Connection } from '@solana/web3.js';
+import { SOLANA_GENESIS_HASHES, type SolanaEnvironment } from './constants.js';
 
 const SOLANA_EXPLORER_BASE_URL = 'https://explorer.solana.com';
+
+/**
+ * Authoritatively infer the cluster from an RPC connection via its genesis hash. This is
+ * provider-agnostic (works for private RPCs like Helius/Alchemy/QuickNode) and never inspects the
+ * RPC URL, so it cannot leak API keys embedded in the URL.
+ *
+ * @returns the matching cluster, or `undefined` for localhost / unknown custom validators.
+ */
+export async function resolveClusterByGenesisHash(
+  connection: Connection
+): Promise<SolanaEnvironment | undefined> {
+  const hash = await connection.getGenesisHash();
+  const match = (
+    Object.keys(SOLANA_GENESIS_HASHES) as Array<keyof typeof SOLANA_GENESIS_HASHES>
+  ).find(env => SOLANA_GENESIS_HASHES[env] === hash);
+  return match;
+}
 
 function getClusterQuery(env: SolanaEnvironment): string {
   if (env === 'mainnet') {

--- a/src/utils/finalize-transaction.ts
+++ b/src/utils/finalize-transaction.ts
@@ -3,18 +3,13 @@ import { TransactionBuilder } from '../core/transaction-builder.js';
 import type { CommandContext } from '../types/command.js';
 import type { GeneratedTransaction } from '../types/index.js';
 import { TransactionDisplay } from './display.js';
-import { loadKeypair, executeTransaction } from './transaction-executor.js';
+import { executeTransaction } from './transaction-executor.js';
+import { loadSignerKeypair } from './keypair.js';
+import { resolveClusterByGenesisHash } from './explorer.js';
 import type { SolanaEnvironment } from './constants.js';
 
 function getGlobalOptions(command: CommandContext) {
   return command.parent?.parent?.opts() || command.parent?.opts() || {};
-}
-
-function expandHomePath(path: string): string {
-  if (path.startsWith('~/')) {
-    return `${process.env.HOME || process.env.USERPROFILE || ''}/${path.slice(2)}`;
-  }
-  return path;
 }
 
 /**
@@ -37,8 +32,7 @@ export async function finalizeTransaction(opts: {
     return tx;
   }
 
-  const keypairPath = expandHomePath(globalOptions.keypair!);
-  const keypair = loadKeypair(keypairPath);
+  const keypair = loadSignerKeypair(globalOptions);
 
   if (!keypair.publicKey.equals(payer)) {
     throw new Error(
@@ -51,11 +45,44 @@ export async function finalizeTransaction(opts: {
     throw new Error(`Transaction simulation failed${simError}`);
   }
 
+  // Verify the local keypair can satisfy ALL required signatures before announcing/sending.
+  // The build-time simulation above runs unsigned (sigVerify:false) for the Squads path, so it
+  // cannot catch a transaction that still requires a signature we don't hold. Re-simulate the signed
+  // transaction with sigVerify enabled to fail fast on that case.
+  const signedSim = await txBuilder.simulateSignedTransaction(instructions, payer, keypair);
+  if (!signedSim.success) {
+    throw new Error(
+      'Signature verification failed in simulation. In --execute mode only your keypair signs, but ' +
+        'this transaction still requires another signature. For an SPL multisig, pass only key(s) ' +
+        'you hold in --multisig-signers (a 1-of-N multisig needs just your own member key); if the ' +
+        "threshold requires co-signers you don't control, it can't be executed locally — use Squads " +
+        `mode (omit --execute). Details: ${signedSim.error}`
+    );
+  }
+
   const rpcUrl = globalOptions.resolvedRpcUrl!;
   const connection = new Connection(rpcUrl);
+
+  // Resolve the cluster authoritatively from the chain's genesis hash when --env was not given, so
+  // both the mainnet warning and the explorer link are correct even with --rpc-url. Never throw here.
+  let env = globalOptions.environment as SolanaEnvironment | undefined;
+  if (!env) {
+    try {
+      env = await resolveClusterByGenesisHash(connection);
+    } catch {
+      // leave undefined — a missing cluster only degrades the explorer link, not execution
+    }
+  }
+
+  TransactionDisplay.displayExecutionBanner({
+    signer: keypair.publicKey.toBase58(),
+    instructionName,
+    env,
+    rpcUrl,
+  });
+
   const signature = await executeTransaction(connection, instructions, [keypair]);
 
-  const env = globalOptions.environment as SolanaEnvironment | undefined;
   TransactionDisplay.displayExecutionResults(signature, instructionName, env);
   return tx;
 }

--- a/src/utils/keypair.ts
+++ b/src/utils/keypair.ts
@@ -1,0 +1,87 @@
+import type { Command } from 'commander';
+import { Keypair } from '@solana/web3.js';
+import { loadKeypair } from './transaction-executor.js';
+import { DEFAULT_KEYPAIR_PATH } from './constants.js';
+import type { GlobalCommandOptions } from '../types/command.js';
+
+/**
+ * Expand a leading `~/` to the user's home directory.
+ */
+export function expandHomePath(path: string): string {
+  if (path.startsWith('~/')) {
+    return `${process.env.HOME || process.env.USERPROFILE || ''}/${path.slice(2)}`;
+  }
+  return path;
+}
+
+/**
+ * Resolve the keypair path to load for --execute mode.
+ * Uses --keypair when provided, otherwise the default Solana CLI keypair.
+ */
+export function resolveKeypairPath(globalOpts: GlobalCommandOptions): string {
+  return expandHomePath(globalOpts.keypair ?? DEFAULT_KEYPAIR_PATH);
+}
+
+/**
+ * Load the signer keypair for --execute mode, caching it on the global options
+ * object so it is only read from disk once per invocation. Prints a friendly
+ * message and exits if the file cannot be loaded.
+ */
+export function loadSignerKeypair(globalOpts: GlobalCommandOptions): Keypair {
+  if (globalOpts._signerKeypair) {
+    return globalOpts._signerKeypair;
+  }
+
+  const keypairPath = resolveKeypairPath(globalOpts);
+  try {
+    const keypair = loadKeypair(keypairPath);
+    globalOpts._signerKeypair = keypair;
+    return keypair;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`❌ Could not load keypair: ${message}`);
+    console.error(
+      '💡 Pass --keypair <path>, or run `solana-keygen new` to create the default one.'
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * In --execute mode, auto-derive --authority from the signer keypair so the user
+ * does not have to retype their own public key.
+ *
+ * - No-op when --execute is not set (encode/Squads mode keeps --authority required).
+ * - When --authority is omitted, sets it to the keypair's public key.
+ * - When --authority is provided, enforces that it matches the keypair.
+ *
+ * Sets the value on both the live `options` object (so the hook's own validation
+ * sees it) and via `setOptionValue` (so the action handler sees it).
+ */
+export function applyExecuteAuthority(
+  thisCommand: Command,
+  options: Record<string, unknown>,
+  globalOpts: GlobalCommandOptions
+): void {
+  if (!globalOpts.execute) {
+    return;
+  }
+
+  const signer = loadSignerKeypair(globalOpts).publicKey.toBase58();
+  const provided = options.authority as string | undefined;
+
+  if (!provided) {
+    options.authority = signer;
+    thisCommand.setOptionValue('authority', signer);
+    console.log(`🔑 Authority derived from keypair: ${signer}`);
+    return;
+  }
+
+  if (provided !== signer) {
+    console.error(`❌ --authority ${provided} does not match keypair ${signer}`);
+    console.error(
+      '💡 In --execute mode, omit --authority (it defaults to your keypair) or pass a matching one.'
+    );
+    process.exit(1);
+  }
+}

--- a/src/utils/transaction-executor.ts
+++ b/src/utils/transaction-executor.ts
@@ -35,7 +35,12 @@ export function loadKeypair(path: string): Keypair {
  * Execute a set of instructions as a single transaction
  *
  * Uses 'finalized' commitment for blockhash to reduce expiration issues on slow/congested RPCs.
- * Implements automatic retry logic for transient RPC failures.
+ *
+ * The transaction is built and signed exactly ONCE, before the retry loop. Retries only
+ * re-broadcast that same signed transaction — because the signature is identical, the network
+ * de-duplicates it, so a retry (e.g. after a confirmation timeout where the first send already
+ * landed) can never execute the instructions twice. Re-signing with a fresh blockhash would create
+ * a new signature and risk double execution (e.g. a double mint), which is exactly what we avoid.
  *
  * @param connection - Solana RPC connection
  * @param instructions - Transaction instructions to execute
@@ -67,30 +72,28 @@ export async function executeTransaction(
     'Preparing to execute transaction'
   );
 
+  // Build and sign ONCE so every retry re-broadcasts an identical signature (see note above).
+  // Use 'finalized' commitment for a more reliable blockhash on slow RPCs.
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('finalized');
+  logger.debug({ blockhash, lastValidBlockHeight }, 'Building and signing transaction');
+
+  const tx = new Transaction();
+  tx.recentBlockhash = blockhash;
+  tx.lastValidBlockHeight = lastValidBlockHeight;
+  tx.feePayer = feePayer.publicKey;
+  tx.add(...instructions);
+  tx.sign(...signers);
+  const rawTransaction = tx.serialize();
+
   const maxRetries = 3;
   let lastError: Error | null = null;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      logger.debug({ attempt, maxRetries }, 'Fetching latest blockhash');
+      logger.debug({ attempt, maxRetries }, 'Sending signed transaction');
 
-      // Use 'finalized' commitment for more reliable blockhash on slow RPCs
-      const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('finalized');
-
-      logger.debug({ blockhash, lastValidBlockHeight }, 'Building transaction');
-
-      // Build and sign transaction
-      const tx = new Transaction();
-      tx.recentBlockhash = blockhash;
-      tx.lastValidBlockHeight = lastValidBlockHeight;
-      tx.feePayer = feePayer.publicKey;
-      tx.add(...instructions);
-      tx.sign(...signers);
-
-      logger.debug({ attempt }, 'Sending signed transaction');
-
-      // Send with preflight checks and retries
-      const rawTransaction = tx.serialize();
+      // Re-broadcasting the same signed transaction is idempotent (identical signature), so a retry
+      // after a confirmation timeout cannot double-execute the instructions.
       const signature = await connection.sendRawTransaction(rawTransaction, {
         skipPreflight: false,
         maxRetries: 2,


### PR DESCRIPTION
This pull request introduces several improvements to the CLI's `--execute` mode, enhancing both user experience and safety. The main changes ensure that the signer keypair is loaded efficiently, the `--authority` option is auto-derived and validated, and that transactions are simulated with signature verification before execution. Additionally, the code now provides clearer warnings and explorer links, and robustly infers the Solana cluster from the chain's genesis hash. Below are the most important changes:

**Execute Mode Keypair Handling and Authority Validation**
* Added `applyExecuteAuthority` and related utilities in `src/utils/keypair.ts`, which auto-derive `--authority` from the signer keypair in `--execute` mode, enforce that any provided `--authority` matches the keypair, and cache the loaded keypair for efficiency. This is now applied in all command modules. [[1]](diffhunk://#diff-54748be64d45244bde5d5489723e52e0bdab1cbff1ba036026f3ff4fd7276523R1-R87) [[2]](diffhunk://#diff-c3ff58d34a00c969bc093bee3827265d8a6e2a2f7b6eb70b6386bf0d87093971R15) [[3]](diffhunk://#diff-c3ff58d34a00c969bc093bee3827265d8a6e2a2f7b6eb70b6386bf0d87093971R130) [[4]](diffhunk://#diff-204e8c6a83aac13fdcac48008301204020e62c7265eac77cb1be4752311d0efdR19) [[5]](diffhunk://#diff-204e8c6a83aac13fdcac48008301204020e62c7265eac77cb1be4752311d0efdR153) [[6]](diffhunk://#diff-23e22008f559106da960ebded0c1a195d1ffff21ee9469daf2c411acaa6e6389R3) [[7]](diffhunk://#diff-23e22008f559106da960ebded0c1a195d1ffff21ee9469daf2c411acaa6e6389R21) [[8]](diffhunk://#diff-4ec98b9e344350332e3561ccd9367db00f3c9f37ebc9fdf125470e4c6365c127R9) [[9]](diffhunk://#diff-4ec98b9e344350332e3561ccd9367db00f3c9f37ebc9fdf125470e4c6365c127R64) [[10]](diffhunk://#diff-2e9b8c41533188140a99e60f9df8437ffba99046511b7d2fe6e36e80dd663a17R8) [[11]](diffhunk://#diff-2e9b8c41533188140a99e60f9df8437ffba99046511b7d2fe6e36e80dd663a17R65)
* Updated the global options type to cache the loaded signer keypair. [[1]](diffhunk://#diff-9149d6429abcbbb81c781d7e3a70b730138491a2122f387f96a0f8fa04d1ccf1R1-R2) [[2]](diffhunk://#diff-9149d6429abcbbb81c781d7e3a70b730138491a2122f387f96a0f8fa04d1ccf1R13-R14)

**Transaction Simulation and Safety Checks**
* Added `simulateSignedTransaction` to `TransactionBuilder`, ensuring that all required signatures are present before sending a transaction in `--execute` mode, and failing fast if not.
* Updated `finalizeTransaction` to use the new keypair loading and simulation logic, giving clear errors if the transaction can't be signed by the local keypair alone. [[1]](diffhunk://#diff-2e392a2d9a8d55a447584cf36b25ed4897f603bda5cc53b38950302c9cdaaf18L6-L19) [[2]](diffhunk://#diff-2e392a2d9a8d55a447584cf36b25ed4897f603bda5cc53b38950302c9cdaaf18L40-R35) [[3]](diffhunk://#diff-2e392a2d9a8d55a447584cf36b25ed4897f603bda5cc53b38950302c9cdaaf18R48-L58)

**Improved User Feedback and Cluster Detection**
* Added a prominent execution banner in `TransactionDisplay.displayExecutionBanner`, warning users when executing on mainnet and showing signer, instruction, and RPC details.
* Enhanced transaction result display to avoid leaking RPC URLs and to handle custom/unknown clusters gracefully.
* Added `SOLANA_GENESIS_HASHES` and `resolveClusterByGenesisHash` to infer the cluster from the chain's genesis hash, ensuring accurate warnings and explorer links even with custom RPC URLs. [[1]](diffhunk://#diff-e8d0a358ae2fb090c56f00a058050983cc9691b7d3622ddd443170017123e7d9R15-R24) [[2]](diffhunk://#diff-8b25ea48a7152b1f7b0e49e68861be5451ce681b46e4d3894373c7bf2975ea64L1-R22)

**Other Improvements**
* In `create-lookup-table.ts`, clarified that slot-expiry warnings are only shown in non-execute mode. [[1]](diffhunk://#diff-90eeef2a2e7fa144594e2d06b1a8e776215dbb632cd4238be1154b4cf5cf74a6R56-R60) [[2]](diffhunk://#diff-90eeef2a2e7fa144594e2d06b1a8e776215dbb632cd4238be1154b4cf5cf74a6R77)

These changes collectively make `--execute` mode safer, more user-friendly, and robust against configuration errors.