### PR TITLE
Add --format base64 option for transaction output

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,12 @@ The CLI requires network configuration through either `--env` or `--rpc-url`:
 
 #### Transaction Output Format
 
-By default, generated transactions are encoded as **Base58** for Squads multisig import. To output **Base64** instead, pass `--format base64` or set the env var in your shell:
+The CLI generates a serialized Solana transaction and can display it in either Base58 or Base64 encoding.
+
+- `base58` (default): Recommended for Solana-native workflows such as Squads multisig transaction import.
+- `base64`: Recommended for API-based integrations and custody platforms such as Fireblocks.
+
+Both formats represent the exact same serialized transaction bytes. The selected format only changes how the transaction is encoded for transport or display.
 
 ```bash
 export CCIP_TX_OUTPUT_FORMAT=base64

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ pnpm bs58 burnmint-token-pool --program-id "..." --env devnet --instruction tran
 | `--env <environment>` | `--environment` | string  | Solana environment (mainnet, devnet, testnet, localhost) |
 | `--rpc-url <url>`     |                 | string  | Custom Solana RPC endpoint URL                           |
 | `--verbose`           |                 | boolean | Enable debug-level logging                               |
+| `--format <format>`   |                 | string  | Transaction output format (`base58`, `base64`; default: `base58`) |
 | `--version`           | `-v`            |         | Display version information                              |
 | `--help`              | `-h`            |         | Display help information                                 |
 
@@ -154,6 +155,20 @@ The CLI requires network configuration through either `--env` or `--rpc-url`:
 - **Environment-based** (recommended): Uses predefined RPC endpoints
 - **Custom RPC**: Specify any Solana RPC endpoint
 - **Mutual exclusivity**: Cannot use both options simultaneously
+
+#### Transaction Output Format
+
+By default, generated transactions are encoded as **Base58** for Squads multisig import. To output **Base64** instead:
+
+```bash
+pnpm bs58 --env devnet --format base64 \
+  burnmint-token-pool --instruction accept-ownership \
+  --program-id "Your_Program_ID" \
+  --mint "Token_Mint_Address" \
+  --authority "New_Authority_PublicKey"
+```
+
+Both formats encode the same serialized transaction bytes. `--format` only affects display output, accepts `base58` or `base64` (case-insensitive), and is ignored when using `--execute`.
 
 **Supported Environments:**
 
@@ -2078,7 +2093,9 @@ pnpm bs58 burnmint-token-pool --rpc-url "https://custom-endpoint.com" --instruct
 
 ### Transaction Data
 
-The CLI outputs structured transaction information:
+The CLI outputs structured transaction information. By default, transaction data is Base58-encoded. With `--format base64`, only the Base64-encoded data is shown instead.
+
+**Default output (`base58`):**
 
 ```
 🎉 Transaction generated successfully!
@@ -2118,6 +2135,10 @@ The CLI outputs structured transaction information:
    • Estimated compute units: 7,562
    • This transaction is valid until the blockhash expires (~2 minutes)
 ```
+
+**Base64 output (`--format base64`):**
+
+Same structure as above, with `Base64 length` in the details section and Base64-encoded data in the copy-paste block.
 
 ### Log Levels
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ pnpm bs58 --env devnet --format base64 \
 
 **Precedence:** `--format` flag → `CCIP_TX_OUTPUT_FORMAT` env var → `base58` default.
 
-Both formats encode the same serialized transaction bytes. Format settings only affect display output, accept `base58` or `base64` (case-insensitive), and are ignored when using `--execute`.
+Both formats encode the same serialized transaction bytes. Format settings only affect display output, accept `base58` or `base64` (case-insensitive). When using `--execute`, the transaction is signed and submitted directly to the blockchain. No transaction payload is emitted, so the output format setting has no effect.
 
 **Supported Environments:**
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ pnpm bs58 burnmint-token-pool --program-id "..." --env devnet --instruction tran
 | `--env <environment>` | `--environment` | string  | Solana environment (mainnet, devnet, testnet, localhost) |
 | `--rpc-url <url>`     |                 | string  | Custom Solana RPC endpoint URL                           |
 | `--verbose`           |                 | boolean | Enable debug-level logging                               |
-| `--format <format>`   |                 | string  | Transaction output format (`base58`, `base64`; default: `base58`) |
+| `--format <format>`   |                 | string  | Transaction output format (`base58`, `base64`; default: `base58`, or `CCIP_TX_OUTPUT_FORMAT` env var) |
 | `--version`           | `-v`            |         | Display version information                              |
 | `--help`              | `-h`            |         | Display help information                                 |
 
@@ -158,7 +158,34 @@ The CLI requires network configuration through either `--env` or `--rpc-url`:
 
 #### Transaction Output Format
 
-By default, generated transactions are encoded as **Base58** for Squads multisig import. To output **Base64** instead:
+By default, generated transactions are encoded as **Base58** for Squads multisig import. To output **Base64** instead, pass `--format base64` or set the env var in your shell:
+
+```bash
+export CCIP_TX_OUTPUT_FORMAT=base64
+
+pnpm bs58 --env devnet \
+  burnmint-token-pool --instruction accept-ownership \
+  --program-id "Your_Program_ID" \
+  --mint "Token_Mint_Address" \
+  --authority "New_Authority_PublicKey"
+```
+
+Or persist it in a local `.env` file and load it into your shell session:
+
+```bash
+echo 'export CCIP_TX_OUTPUT_FORMAT=base64' > .env
+source .env
+
+pnpm bs58 --env devnet \
+  burnmint-token-pool --instruction accept-ownership \
+  --program-id "Your_Program_ID" \
+  --mint "Token_Mint_Address" \
+  --authority "New_Authority_PublicKey"
+```
+
+> **Note:** The CLI does not auto-load `.env` files — you must `source .env` (or `export` manually) so the variable is available to the process. Use `export` in the file so child processes inherit it. `.env` is gitignored.
+
+Or per invocation with the flag:
 
 ```bash
 pnpm bs58 --env devnet --format base64 \
@@ -168,7 +195,9 @@ pnpm bs58 --env devnet --format base64 \
   --authority "New_Authority_PublicKey"
 ```
 
-Both formats encode the same serialized transaction bytes. `--format` only affects display output, accepts `base58` or `base64` (case-insensitive), and is ignored when using `--execute`.
+**Precedence:** `--format` flag → `CCIP_TX_OUTPUT_FORMAT` env var → `base58` default.
+
+Both formats encode the same serialized transaction bytes. Format settings only affect display output, accept `base58` or `base64` (case-insensitive), and are ignored when using `--execute`.
 
 **Supported Environments:**
 

--- a/src/core/transaction-builder.ts
+++ b/src/core/transaction-builder.ts
@@ -76,6 +76,7 @@ export class TransactionBuilder {
         const serializedTransaction = legacyMessage.serialize();
         const transactionSizeBytes = serializedTransaction.length;
         const base58Encoded = bs58.encode(serializedTransaction);
+        const base64Encoded = Buffer.from(serializedTransaction).toString('base64');
         const hexEncoded = Buffer.from(serializedTransaction).toString('hex');
 
         // Extract account information
@@ -98,6 +99,7 @@ export class TransactionBuilder {
         const result: GeneratedTransaction = {
           instruction: instructionName || 'unknown',
           base58: base58Encoded,
+          base64: base64Encoded,
           hex: hexEncoded,
           accounts: accounts.map((account, index) => ({
             index,
@@ -134,6 +136,7 @@ export class TransactionBuilder {
             instructionName,
             transactionSize: `${transactionSizeBytes} bytes`,
             base58Length: `${base58Encoded.length} characters`,
+            base64Length: `${base64Encoded.length} characters`,
             hexLength: `${hexEncoded.length} characters`,
             accountCount: accounts.length,
             signerCount: signers.length,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,10 @@ import { logger } from './utils/logger.js';
 import {
   CLI_CONFIG,
   DEFAULT_KEYPAIR_PATH,
-  DEFAULT_TRANSACTION_OUTPUT_FORMAT,
-  parseTransactionOutputFormat,
+  resolveTransactionOutputFormat,
   SOLANA_ENVIRONMENTS,
   TRANSACTION_OUTPUT_FORMATS,
+  TX_OUTPUT_FORMAT_ENV_VAR,
   type SolanaEnvironment,
 } from './utils/constants.js';
 
@@ -42,8 +42,7 @@ async function main(): Promise<void> {
     )
     .option(
       '--format <format>',
-      `Transaction output format (${TRANSACTION_OUTPUT_FORMATS.join('|')})`,
-      DEFAULT_TRANSACTION_OUTPUT_FORMAT
+      `Transaction output format (${TRANSACTION_OUTPUT_FORMATS.join('|')}; default: base58, or ${TX_OUTPUT_FORMAT_ENV_VAR} env var)`
     )
     .hook('preAction', thisCommand => {
       const opts = thisCommand.opts();
@@ -80,14 +79,18 @@ async function main(): Promise<void> {
         process.exit(1);
       }
 
-      // Validate transaction output format
-      const parsedFormat = parseTransactionOutputFormat(opts.format);
-      if (!parsedFormat) {
-        console.error(`❌ Invalid format: ${opts.format}`);
+      // Resolve transaction output format: --format > CCIP_TX_OUTPUT_FORMAT env > base58
+      const formatResolution = resolveTransactionOutputFormat(opts.format);
+      if (!formatResolution.ok) {
+        if (formatResolution.source === 'cli') {
+          console.error(`❌ Invalid format: ${formatResolution.value}`);
+        } else {
+          console.error(`❌ Invalid ${TX_OUTPUT_FORMAT_ENV_VAR}: ${formatResolution.value}`);
+        }
         console.error(`Available formats: ${TRANSACTION_OUTPUT_FORMATS.join(', ')}`);
         process.exit(1);
       }
-      opts.format = parsedFormat;
+      opts.format = formatResolution.format;
 
       // Store resolved RPC URL for easy access by subcommands
       if (hasRpcUrl) {
@@ -140,7 +143,7 @@ async function main(): Promise<void> {
     console.log('💡 Tips:');
     console.log('  • Use --verbose for detailed logging');
     console.log(
-      '  • Transaction data is Base58-encoded by default (use --format base64 for Base64)'
+      `  • Transaction data is Base58 by default (use --format or export ${TX_OUTPUT_FORMAT_ENV_VAR}=base64)`
     );
     console.log('  • Use --execute to sign and send with your local keypair');
     console.log('  • --keypair defaults to ~/.config/solana/id.json when --execute is set');

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,10 @@ import { logger } from './utils/logger.js';
 import {
   CLI_CONFIG,
   DEFAULT_KEYPAIR_PATH,
+  DEFAULT_TRANSACTION_OUTPUT_FORMAT,
+  parseTransactionOutputFormat,
   SOLANA_ENVIRONMENTS,
+  TRANSACTION_OUTPUT_FORMATS,
   type SolanaEnvironment,
 } from './utils/constants.js';
 
@@ -31,11 +34,16 @@ async function main(): Promise<void> {
     .option('--rpc-url <url>', 'Custom Solana RPC URL (overrides --env if provided)')
     .option(
       '--execute',
-      'Sign and send the transaction with a local keypair instead of outputting Base58'
+      'Sign and send the transaction with a local keypair instead of outputting encoded transaction data'
     )
     .option(
       '--keypair <path>',
       `Path to keypair file (default: ${DEFAULT_KEYPAIR_PATH} when --execute is set)`
+    )
+    .option(
+      '--format <format>',
+      `Transaction output format (${TRANSACTION_OUTPUT_FORMATS.join('|')})`,
+      DEFAULT_TRANSACTION_OUTPUT_FORMAT
     )
     .hook('preAction', thisCommand => {
       const opts = thisCommand.opts();
@@ -71,6 +79,15 @@ async function main(): Promise<void> {
         console.error(`Available environments: ${Object.keys(SOLANA_ENVIRONMENTS).join(', ')}`);
         process.exit(1);
       }
+
+      // Validate transaction output format
+      const parsedFormat = parseTransactionOutputFormat(opts.format);
+      if (!parsedFormat) {
+        console.error(`❌ Invalid format: ${opts.format}`);
+        console.error(`Available formats: ${TRANSACTION_OUTPUT_FORMATS.join(', ')}`);
+        process.exit(1);
+      }
+      opts.format = parsedFormat;
 
       // Store resolved RPC URL for easy access by subcommands
       if (hasRpcUrl) {
@@ -122,7 +139,9 @@ async function main(): Promise<void> {
     console.log('');
     console.log('💡 Tips:');
     console.log('  • Use --verbose for detailed logging');
-    console.log('  • Transaction data is Base58-encoded for Squads multisig');
+    console.log(
+      '  • Transaction data is Base58-encoded by default (use --format base64 for Base64)'
+    );
     console.log('  • Use --execute to sign and send with your local keypair');
     console.log('  • --keypair defaults to ~/.config/solana/id.json when --execute is set');
     console.log('  • Always test on Devnet first!');

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -1,4 +1,5 @@
 import type { Keypair } from '@solana/web3.js';
+import type { TransactionOutputFormat } from '../utils/constants.js';
 
 /**
  * Global CLI options available on the root Commander program
@@ -10,6 +11,7 @@ export interface GlobalCommandOptions {
   resolvedRpcUrl?: string;
   execute?: boolean;
   keypair?: string;
+  format?: TransactionOutputFormat;
   /** Cached signer keypair, loaded once per invocation in --execute mode */
   _signerKeypair?: Keypair;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -744,6 +744,7 @@ export interface TransactionOptions {
 export interface GeneratedTransaction {
   instruction: string; // Instruction name
   base58: string; // BS58 encoded transaction
+  base64: string; // Base64 encoded transaction
   hex: string; // Hex encoded transaction
   accounts: {
     pubkey: string;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -58,6 +58,9 @@ export type TransactionOutputFormat = (typeof TRANSACTION_OUTPUT_FORMATS)[number
 
 export const DEFAULT_TRANSACTION_OUTPUT_FORMAT: TransactionOutputFormat = 'base58';
 
+/** Shell env var for default transaction output format (e.g. `export CCIP_TX_OUTPUT_FORMAT=base64`) */
+export const TX_OUTPUT_FORMAT_ENV_VAR = 'CCIP_TX_OUTPUT_FORMAT';
+
 export function parseTransactionOutputFormat(
   value: string | undefined
 ): TransactionOutputFormat | null {
@@ -69,6 +72,36 @@ export function parseTransactionOutputFormat(
   return TRANSACTION_OUTPUT_FORMATS.includes(normalized as TransactionOutputFormat)
     ? (normalized as TransactionOutputFormat)
     : null;
+}
+
+export type TransactionOutputFormatResolution =
+  | { ok: true; format: TransactionOutputFormat }
+  | { ok: false; source: 'cli' | 'env'; value: string };
+
+/**
+ * Resolve output format with precedence: CLI `--format` > `CCIP_TX_OUTPUT_FORMAT` env > base58 default.
+ */
+export function resolveTransactionOutputFormat(
+  cliFormat?: string
+): TransactionOutputFormatResolution {
+  if (cliFormat !== undefined && cliFormat !== '') {
+    const parsed = parseTransactionOutputFormat(cliFormat);
+    if (!parsed) {
+      return { ok: false, source: 'cli', value: cliFormat };
+    }
+    return { ok: true, format: parsed };
+  }
+
+  const envValue = process.env[TX_OUTPUT_FORMAT_ENV_VAR];
+  if (envValue !== undefined && envValue !== '') {
+    const parsed = parseTransactionOutputFormat(envValue);
+    if (!parsed) {
+      return { ok: false, source: 'env', value: envValue };
+    }
+    return { ok: true, format: parsed };
+  }
+
+  return { ok: true, format: DEFAULT_TRANSACTION_OUTPUT_FORMAT };
 }
 
 export function getEncodedTransactionData(

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -50,6 +50,35 @@ export const DEFAULT_TRANSACTION_CONFIG = {
 } as const;
 
 /**
+ * Supported transaction output encodings for multisig import
+ */
+export const TRANSACTION_OUTPUT_FORMATS = ['base58', 'base64'] as const;
+
+export type TransactionOutputFormat = (typeof TRANSACTION_OUTPUT_FORMATS)[number];
+
+export const DEFAULT_TRANSACTION_OUTPUT_FORMAT: TransactionOutputFormat = 'base58';
+
+export function parseTransactionOutputFormat(
+  value: string | undefined
+): TransactionOutputFormat | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.toLowerCase();
+  return TRANSACTION_OUTPUT_FORMATS.includes(normalized as TransactionOutputFormat)
+    ? (normalized as TransactionOutputFormat)
+    : null;
+}
+
+export function getEncodedTransactionData(
+  transaction: { base58: string; base64: string },
+  format: TransactionOutputFormat = DEFAULT_TRANSACTION_OUTPUT_FORMAT
+): string {
+  return format === 'base64' ? transaction.base64 : transaction.base58;
+}
+
+/**
  * CLI configuration constants
  */
 export const CLI_CONFIG = {

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -2,6 +2,11 @@ import type { GeneratedTransaction } from '../types/index.js';
 import { logger } from './logger.js';
 import { getTransactionExplorerUrl } from './explorer.js';
 import type { SolanaEnvironment } from './constants.js';
+import {
+  DEFAULT_TRANSACTION_OUTPUT_FORMAT,
+  getEncodedTransactionData,
+  type TransactionOutputFormat,
+} from './constants.js';
 
 /**
  * Utility for displaying transaction data with beautiful formatting
@@ -11,8 +16,16 @@ export class TransactionDisplay {
    * Display transaction results in a user-friendly format
    * @param transaction The generated transaction
    * @param instructionName The instruction name for context
+   * @param format Output encoding for the copy-paste transaction data
    */
-  static displayResults(transaction: GeneratedTransaction, instructionName: string): void {
+  static displayResults(
+    transaction: GeneratedTransaction,
+    instructionName: string,
+    format: TransactionOutputFormat = DEFAULT_TRANSACTION_OUTPUT_FORMAT
+  ): void {
+    const encodedData = getEncodedTransactionData(transaction, format);
+    const formatLabel = format === 'base64' ? 'Base64' : 'Base58';
+
     logger.info('');
     logger.info('🎉 Transaction generated successfully!');
     logger.info('');
@@ -21,41 +34,41 @@ export class TransactionDisplay {
     logger.info('📋 Transaction Details:');
     logger.info(`   Instruction: ${instructionName}`);
     logger.info(`   Size: ${Math.floor(transaction.hex.length / 2)} bytes`);
-    logger.info(`   Base58 length: ${transaction.base58.length} characters`);
+    logger.info(`   ${formatLabel} length: ${encodedData.length} characters`);
     logger.info(
       `   Compute units: ${transaction.metadata.computeUnits?.toLocaleString() || 'Unknown'}`
     );
     logger.info(`   Generated: ${transaction.metadata.generatedAt}`);
     logger.info('');
 
-    // Base58 transaction data - highlighted for easy copy/paste
-    this.displayBase58Transaction(transaction.base58);
+    // Encoded transaction data - highlighted for easy copy/paste
+    this.displayEncodedTransaction(encodedData, formatLabel);
     logger.info('');
 
     // Account information
     this.displayAccountInfo(transaction);
 
     // Usage instructions
-    this.displayUsageInstructions();
+    this.displayUsageInstructions(format);
 
     // Final notes
     this.displayNotes(transaction);
   }
 
   /**
-   * Display Base58 transaction data in a beautiful, copy-friendly format
+   * Display encoded transaction data in a beautiful, copy-friendly format
    * Note: Uses console.log for clean copy-paste experience (no timestamps)
    */
-  private static displayBase58Transaction(base58: string): void {
-    logger.info('🔗 Transaction Data (Base58):');
+  private static displayEncodedTransaction(encodedData: string, formatLabel: string): void {
+    logger.info(`🔗 Transaction Data (${formatLabel}):`);
     logger.info('');
 
-    // Clean, simple approach - just highlight and the raw Base58
+    // Clean, simple approach - just highlight and the raw encoded data
     console.log('🎯 COPY TRANSACTION DATA BELOW:');
     console.log('');
-    console.log(base58);
+    console.log(encodedData);
     console.log('');
-    console.log('─'.repeat(Math.min(80, base58.length)));
+    console.log('─'.repeat(Math.min(80, encodedData.length)));
 
     logger.info('💡 Triple-click the line above to select the entire transaction data');
   }
@@ -93,12 +106,18 @@ export class TransactionDisplay {
   /**
    * Display usage instructions
    */
-  private static displayUsageInstructions(): void {
+  private static displayUsageInstructions(format: TransactionOutputFormat): void {
+    const formatLabel = format === 'base64' ? 'Base64' : 'Base58';
+
     logger.info('💡 Usage Instructions:');
-    logger.info('   1. 📋 Copy the Base58 transaction data from the box above');
-    logger.info('   2. 🔗 Open your Squads multisig interface');
+    logger.info(`   1. 📋 Copy the ${formatLabel} transaction data from the box above`);
+    if (format === 'base58') {
+      logger.info('   2. 🔗 Open your Squads multisig interface');
+    } else {
+      logger.info('   2. 🔗 Open your multisig interface');
+    }
     logger.info('   3. ➕ Create a "Custom Transaction" or "Raw Transaction"');
-    logger.info('   4. 📝 Paste the Base58 data into the transaction field');
+    logger.info(`   4. 📝 Paste the ${formatLabel} data into the transaction field`);
     logger.info('   5. ✅ Review all accounts and parameters carefully');
     logger.info('   6. 👥 Get required signatures from multisig members');
     logger.info('   7. 🚀 Execute the transaction on Solana');

--- a/src/utils/finalize-transaction.ts
+++ b/src/utils/finalize-transaction.ts
@@ -7,13 +7,14 @@ import { executeTransaction } from './transaction-executor.js';
 import { loadSignerKeypair } from './keypair.js';
 import { resolveClusterByGenesisHash } from './explorer.js';
 import type { SolanaEnvironment } from './constants.js';
+import { DEFAULT_TRANSACTION_OUTPUT_FORMAT, parseTransactionOutputFormat } from './constants.js';
 
 function getGlobalOptions(command: CommandContext) {
   return command.parent?.parent?.opts() || command.parent?.opts() || {};
 }
 
 /**
- * Build and either display Base58 transaction data or execute on-chain with a local keypair.
+ * Build and either display encoded transaction data or execute on-chain with a local keypair.
  */
 export async function finalizeTransaction(opts: {
   txBuilder: TransactionBuilder;
@@ -27,8 +28,11 @@ export async function finalizeTransaction(opts: {
 
   const tx = await txBuilder.buildTransaction(instructions, payer, instructionName);
 
+  const outputFormat =
+    parseTransactionOutputFormat(globalOptions.format) ?? DEFAULT_TRANSACTION_OUTPUT_FORMAT;
+
   if (!globalOptions.execute) {
-    TransactionDisplay.displayResults(tx, instructionName);
+    TransactionDisplay.displayResults(tx, instructionName, outputFormat);
     return tx;
   }
 

--- a/src/utils/finalize-transaction.ts
+++ b/src/utils/finalize-transaction.ts
@@ -7,7 +7,7 @@ import { executeTransaction } from './transaction-executor.js';
 import { loadSignerKeypair } from './keypair.js';
 import { resolveClusterByGenesisHash } from './explorer.js';
 import type { SolanaEnvironment } from './constants.js';
-import { DEFAULT_TRANSACTION_OUTPUT_FORMAT, parseTransactionOutputFormat } from './constants.js';
+import { DEFAULT_TRANSACTION_OUTPUT_FORMAT, resolveTransactionOutputFormat } from './constants.js';
 
 function getGlobalOptions(command: CommandContext) {
   return command.parent?.parent?.opts() || command.parent?.opts() || {};
@@ -28,8 +28,10 @@ export async function finalizeTransaction(opts: {
 
   const tx = await txBuilder.buildTransaction(instructions, payer, instructionName);
 
-  const outputFormat =
-    parseTransactionOutputFormat(globalOptions.format) ?? DEFAULT_TRANSACTION_OUTPUT_FORMAT;
+  const formatResolution = resolveTransactionOutputFormat(globalOptions.format);
+  const outputFormat = formatResolution.ok
+    ? formatResolution.format
+    : DEFAULT_TRANSACTION_OUTPUT_FORMAT;
 
   if (!globalOptions.execute) {
     TransactionDisplay.displayResults(tx, instructionName, outputFormat);


### PR DESCRIPTION
- Adds a global `--format` flag (`base58` | `base64`, default `base58`) so generated transaction calldata can be output as Base64 for consumers that expect it. Also supports `CCIP_TX_OUTPUT_FORMAT` as a shell env var (via `export` or `source .env`) so teams don't need to pass `--format` on every invocation.

- **Precedence:** `--format` flag → `CCIP_TX_OUTPUT_FORMAT` env var → `base58` default.

- Existing Base58/Squads behavior is unchanged when neither the flag nor env var is set.