### PR TITLE
Feat/inspect token and pool ata signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A command-line interface for generating Base58 transaction data from Solana prog
   - [Burnmint Token Pool](#burnmint-token-pool)
     - [Instructions](#instructions)
       - [Initialize Pool](#initialize-pool)
+      - [Create Token Account](#create-token-account)
       - [Transfer Ownership](#transfer-ownership)
       - [Accept Ownership](#accept-ownership)
       - [Set Chain Rate Limit](#set-chain-rate-limit)
@@ -36,6 +37,7 @@ A command-line interface for generating Base58 transaction data from Solana prog
   - [Lockrelease Token Pool](#lockrelease-token-pool)
     - [Instructions](#lockrelease-instructions)
       - [Initialize Pool](#lockrelease-initialize-pool)
+      - [Create Token Account](#lockrelease-create-token-account)
       - [Transfer Ownership](#transfer-ownership)
       - [Accept Ownership](#accept-ownership)
       - [Set Rate Limit Admin](#set-rate-limit-admin)
@@ -60,6 +62,7 @@ A command-line interface for generating Base58 transaction data from Solana prog
       - [Transfer Admin Role](#transfer-admin-role)
       - [Create Lookup Table](#create-lookup-table)
       - [Set Pool](#set-pool)
+      - [Inspect Token](#inspect-token)
   - [SPL Token](#spl-token)
     - [Instructions](#spl-token-instructions)
       - [Create Mint](#create-mint)
@@ -169,26 +172,29 @@ The CLI requires network configuration through either `--env` or `--rpc-url`:
 By default, the CLI generates unsigned Base58 transaction data for multisig import (e.g. Squads). To sign and send directly with a local keypair, add `--execute`:
 
 ```bash
-# Uses default keypair at ~/.config/solana/id.json
+# Uses default keypair at ~/.config/solana/id.json; --authority is auto-derived from the keypair
 pnpm bs58 --env devnet --execute \
   burnmint-token-pool --instruction accept-ownership \
   --program-id "Your_Program_ID" \
-  --mint "Token_Mint_Address" \
-  --authority "Your_EOA_PublicKey"
+  --mint "Token_Mint_Address"
 
 # Custom keypair path
 pnpm bs58 --env devnet --execute --keypair ~/my-wallet.json \
   spl-token --instruction mint \
-  --mint "Token_Mint" --authority "Your_EOA_PublicKey" ...
+  --mint "Token_Mint" --amount 1000000000 --recipient "Owner" ...
 ```
 
 **Requirements and limitations:**
 
-- `--authority` must match the loaded keypair's public key (the EOA is the fee payer and signer)
+- `--authority` is **optional** in `--execute` mode — it defaults to the loaded keypair's public key
+  (the EOA is the fee payer and signer). If you do pass it, it must equal the keypair's public key.
 - `--execute` requires `--env` or `--rpc-url`
-- `--keypair` can only be used with `--execute`
-- Multisig vault addresses cannot be executed locally — omit `--execute` and import Base58 into Squads
-- Read-only commands (`get-state`, `get-chain-config`, `derive-accounts`) do not support `--execute`
+- `--keypair` can only be used with `--execute`; defaults to `~/.config/solana/id.json` (also honors `$SOLANA_KEYPAIR`)
+- Before sending, a `sigVerify` simulation runs; a transaction needing a signer you don't hold (e.g. a
+  multisig member / Pool Signer PDA, or a threshold ≥ 2) is rejected up front.
+- A loud banner prints before sending (with an extra warning on `--env mainnet`). Multisig **vault**
+  addresses can't be executed locally — omit `--execute` and import Base58 into Squads.
+- Read-only commands (`get-state`, `get-chain-config`, `derive-accounts`, `inspect-token`) do not support `--execute`
 
 ## Programs
 
@@ -242,6 +248,38 @@ pnpm bs58 burnmint-token-pool \
 | 4     | Program       | Read-only        | Burn-mint program ID                           |
 | 5     | ProgramData   | Read-only        | Program Data PDA (upgradeable loader)          |
 | 6     | Global Config | Read-only        | Global config PDA (`config`)                   |
+
+##### create-token-account
+
+Create the **pool signer's Associated Token Account** — the pool's token reserve account (owner = the
+pool signer PDA). Required before lock/release liquidity operations and cross-chain transfers. The
+token program (SPL Token vs Token-2022) is auto-detected from the mint, and the instruction is
+idempotent (safe to re-run). Works in both Base58 (Squads) and `--execute` modes.
+
+**📋 Applies To:** Both `burnmint-token-pool` and `lockrelease-token-pool`
+
+**Syntax:**
+
+```bash
+pnpm bs58 burnmint-token-pool --instruction create-token-account [options]
+```
+
+**Options:**
+
+| Option                   | Type      | Required | Description                                            |
+| ------------------------ | --------- | -------- | ------------------------------------------------------ |
+| `--program-id <address>` | PublicKey | Yes      | Token pool program ID                                  |
+| `--mint <address>`       | PublicKey | Yes      | Token mint address                                     |
+| `--authority <address>`  | PublicKey | Yes\*    | Fee payer (\*auto-derived from the keypair in `--execute`) |
+
+**Example (EOA execute, devnet):**
+
+```bash
+pnpm bs58 --env devnet --execute \
+  burnmint-token-pool --instruction create-token-account \
+  --program-id "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB" \
+  --mint "EL4xtGMgYoYtM4FcFnehiQJZFM2AsfqdFikgZK2y9GCo"
+```
 
 ##### transfer-ownership
 
@@ -896,6 +934,19 @@ pnpm bs58 lockrelease-token-pool initialize-pool \
 | 4     | Program       | Read-only        | Lockrelease program ID                           |
 | 5     | ProgramData   | Read-only        | Program Data PDA (upgradeable loader)            |
 | 6     | Global Config | Read-only        | Global config PDA (`config`)                     |
+
+##### lockrelease-create-token-account
+
+Create the pool signer's Associated Token Account (the pool's token reserve). Identical to the
+burnmint [Create Token Account](#create-token-account) — token program auto-detected, idempotent,
+supports `--execute`. For lock/release this reserve must exist before `provide-liquidity`.
+
+```bash
+pnpm bs58 --env devnet --execute \
+  lockrelease-token-pool --instruction create-token-account \
+  --program-id "8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC" \
+  --mint "EL4xtGMgYoYtM4FcFnehiQJZFM2AsfqdFikgZK2y9GCo"
+```
 
 ##### set-rebalancer
 
@@ -1559,6 +1610,47 @@ pnpm bs58 router \
   --authority "EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB" \
   --pool-lookup-table "7fYy8hH2jFqJ3c1kRkq2hFvZf8mYb1vZ1g3i2j4k5L6M" \
   --writable-indexes "[3,4,7]"
+```
+
+##### inspect-token
+
+**Read-only** auditor that reports a token's full CCIP configuration in one command — useful to verify a
+deployment's governance/ownership. It reads:
+
+- **Mint**: token program (SPL vs Token-2022), decimals, supply, mint authority (and, if it is an SPL
+  token multisig, the threshold and members), freeze authority.
+- **Pool state**: owner, proposed owner, rate-limit admin, pool signer PDA, pool token account (and
+  whether it exists).
+- **Token Admin Registry**: administrator, pending administrator, lookup table, decoded writable
+  indexes, version, plus a layout self-check.
+- **Address Lookup Table**: contents, with writable entries and CCIP role labels.
+
+It rejects `--execute` and requires no `--authority`.
+
+**Syntax:**
+
+```bash
+pnpm bs58 router --instruction inspect-token [options]
+```
+
+**Options:**
+
+| Option                          | Type      | Required | Description                                      |
+| ------------------------------- | --------- | -------- | ------------------------------------------------ |
+| `--program-id <address>`        | PublicKey | Yes      | Router program ID                                |
+| `--mint <address>`              | PublicKey | Yes      | Token mint address                               |
+| `--pool-program-id <address>`   | PublicKey | Yes      | Token pool program ID (burnmint or lockrelease)  |
+| `--fee-quoter-program-id <addr>`| PublicKey | No       | Enables CCIP role labels on the ALT entries      |
+
+**Example:**
+
+```bash
+pnpm bs58 router \
+  --env mainnet \
+  --instruction inspect-token \
+  --program-id "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C" \
+  --pool-program-id "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB" \
+  --mint "EL4xtGMgYoYtM4FcFnehiQJZFM2AsfqdFikgZK2y9GCo"
 ```
 
 ### SPL Token

--- a/src/commands/burnmint/create-token-account.ts
+++ b/src/commands/burnmint/create-token-account.ts
@@ -1,0 +1,9 @@
+import { createTokenAccount } from '../shared/create-token-account.js';
+import type { CommandContext, CreateTokenAccountOptions } from '../../types/command.js';
+
+export async function createTokenAccountCommand(
+  options: CreateTokenAccountOptions,
+  command: CommandContext
+): Promise<void> {
+  return createTokenAccount(options, command, 'burnmint-token-pool');
+}

--- a/src/commands/burnmint/index.ts
+++ b/src/commands/burnmint/index.ts
@@ -3,6 +3,7 @@ import { acceptOwnershipCommand } from './accept-ownership.js';
 import { getChainConfigCommand } from './get-chain-config.js';
 import { getStateCommand } from './get-state.js';
 import { initializePoolCommand } from './initialize-pool.js';
+import { createTokenAccountCommand } from './create-token-account.js';
 import { setChainRateLimitCommand } from './set-chain-rate-limit.js';
 import { setRateLimitAdminCommand } from './set-rate-limit-admin.js';
 import { transferOwnershipCommand } from './transfer-ownership.js';
@@ -23,7 +24,7 @@ export function createBurnmintCommands(): Command {
     .alias('bm')
     .requiredOption(
       '--instruction <instruction>',
-      'Instruction to execute (initialize-pool, accept-ownership, transfer-ownership, set-rate-limit-admin, get-state, get-chain-config, init-chain-remote-config, edit-chain-remote-config, set-chain-rate-limit, append-remote-pool-addresses, delete-chain-config, configure-allow-list, remove-from-allow-list)'
+      'Instruction to execute (initialize-pool, create-token-account, accept-ownership, transfer-ownership, set-rate-limit-admin, get-state, get-chain-config, init-chain-remote-config, edit-chain-remote-config, set-chain-rate-limit, append-remote-pool-addresses, delete-chain-config, configure-allow-list, remove-from-allow-list)'
     )
     .option(
       '--program-id <programId>',
@@ -458,6 +459,8 @@ Available Instructions:
       // Route to the appropriate instruction handler
       if (options.instruction === 'initialize-pool') {
         initializePoolCommand(options, command);
+      } else if (options.instruction === 'create-token-account') {
+        createTokenAccountCommand(options, command);
       } else if (options.instruction === 'accept-ownership') {
         acceptOwnershipCommand(options, command);
       } else if (options.instruction === 'transfer-ownership') {
@@ -485,7 +488,7 @@ Available Instructions:
       } else {
         console.error(`❌ Unknown instruction: ${options.instruction}`);
         console.error(
-          'Available instructions: initialize-pool, accept-ownership, transfer-ownership, set-rate-limit-admin, get-state, get-chain-config, init-chain-remote-config, edit-chain-remote-config, append-remote-pool-addresses, delete-chain-config, configure-allow-list, remove-from-allow-list, set-chain-rate-limit'
+          'Available instructions: initialize-pool, create-token-account, accept-ownership, transfer-ownership, set-rate-limit-admin, get-state, get-chain-config, init-chain-remote-config, edit-chain-remote-config, append-remote-pool-addresses, delete-chain-config, configure-allow-list, remove-from-allow-list, set-chain-rate-limit'
         );
         process.exit(1);
       }

--- a/src/commands/lockrelease/create-token-account.ts
+++ b/src/commands/lockrelease/create-token-account.ts
@@ -1,0 +1,9 @@
+import { createTokenAccount } from '../shared/create-token-account.js';
+import type { CommandContext, CreateTokenAccountOptions } from '../../types/command.js';
+
+export async function createTokenAccountCommand(
+  options: CreateTokenAccountOptions,
+  command: CommandContext
+): Promise<void> {
+  return createTokenAccount(options, command, 'lockrelease-token-pool');
+}

--- a/src/commands/lockrelease/index.ts
+++ b/src/commands/lockrelease/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { initializePoolCommand } from './initialize-pool.js';
+import { createTokenAccountCommand } from './create-token-account.js';
 import { acceptOwnershipCommand } from './accept-ownership.js';
 import { getChainConfigCommand } from './get-chain-config.js';
 import { getStateCommand } from './get-state.js';
@@ -27,7 +28,7 @@ export function createLockReleaseCommands(): Command {
     .alias('lr')
     .requiredOption(
       '--instruction <instruction>',
-      'Instruction to execute (initialize-pool, accept-ownership, transfer-ownership, set-rate-limit-admin, get-state, get-chain-config, init-chain-remote-config, edit-chain-remote-config, set-chain-rate-limit, append-remote-pool-addresses, delete-chain-config, configure-allow-list, remove-from-allow-list, provide-liquidity, withdraw-liquidity, set-rebalancer, set-can-accept-liquidity)'
+      'Instruction to execute (initialize-pool, create-token-account, accept-ownership, transfer-ownership, set-rate-limit-admin, get-state, get-chain-config, init-chain-remote-config, edit-chain-remote-config, set-chain-rate-limit, append-remote-pool-addresses, delete-chain-config, configure-allow-list, remove-from-allow-list, provide-liquidity, withdraw-liquidity, set-rebalancer, set-can-accept-liquidity)'
     )
     .option(
       '--program-id <programId>',
@@ -217,6 +218,8 @@ Available Instructions:
       // Route to the appropriate instruction handler
       if (options.instruction === 'initialize-pool') {
         initializePoolCommand(options, command);
+      } else if (options.instruction === 'create-token-account') {
+        createTokenAccountCommand(options, command);
       } else if (options.instruction === 'accept-ownership') {
         acceptOwnershipCommand(options, command);
       } else if (options.instruction === 'transfer-ownership') {
@@ -252,7 +255,7 @@ Available Instructions:
       } else {
         console.error(`❌ Unknown instruction: ${options.instruction}`);
         console.error(
-          'Available instructions: initialize-pool, accept-ownership, transfer-ownership, set-rate-limit-admin, get-state, get-chain-config, init-chain-remote-config, edit-chain-remote-config, append-remote-pool-addresses, delete-chain-config, configure-allow-list, remove-from-allow-list, set-chain-rate-limit, provide-liquidity, withdraw-liquidity, set-rebalancer, set-can-accept-liquidity'
+          'Available instructions: initialize-pool, create-token-account, accept-ownership, transfer-ownership, set-rate-limit-admin, get-state, get-chain-config, init-chain-remote-config, edit-chain-remote-config, append-remote-pool-addresses, delete-chain-config, configure-allow-list, remove-from-allow-list, set-chain-rate-limit, provide-liquidity, withdraw-liquidity, set-rebalancer, set-can-accept-liquidity'
         );
         process.exit(1);
       }

--- a/src/commands/router/index.ts
+++ b/src/commands/router/index.ts
@@ -6,6 +6,7 @@ import { transferAdminRoleCommand } from './transfer-admin-role.js';
 import { setPoolCommand } from './set-pool.js';
 import { createLookupTableCommand } from './create-lookup-table.js';
 import { appendToLookupTableCommand } from './append-to-lookup-table.js';
+import { inspectTokenCommand } from './inspect-token.js';
 import { applyExecuteAuthority } from '../../utils/keypair.js';
 
 /**
@@ -17,7 +18,7 @@ export function createRouterCommands(): Command {
     .alias('r')
     .requiredOption(
       '--instruction <instruction>',
-      'Instruction to execute (owner-propose-administrator, owner-override-pending-administrator, accept-admin-role, transfer-admin-role, set-pool, create-lookup-table, append-to-lookup-table)'
+      'Instruction to execute (owner-propose-administrator, owner-override-pending-administrator, accept-admin-role, transfer-admin-role, set-pool, create-lookup-table, append-to-lookup-table, inspect-token)'
     )
     .option('--program-id <programId>', 'Router program ID (required for most instructions)')
     .option(
@@ -61,10 +62,26 @@ export function createRouterCommands(): Command {
       }
 
       const options = thisCommand.opts();
+      const instr = options.instruction as string;
+
+      // Read-only auditor: no --authority, --execute not supported
+      if (instr === 'inspect-token') {
+        if (globalOpts.execute) {
+          console.error('❌ --execute is not supported for read-only instructions');
+          process.exit(1);
+        }
+        if (!options.programId || !options.mint || !options.poolProgramId) {
+          console.error(
+            '❌ inspect-token requires: --program-id (router), --mint, --pool-program-id'
+          );
+          process.exit(1);
+        }
+        return;
+      }
+
       applyExecuteAuthority(thisCommand, options, globalOpts);
 
       // common - append-to-lookup-table doesn't need program-id
-      const instr = options.instruction as string;
       if (instr !== 'append-to-lookup-table' && (!options.programId || !options.authority)) {
         console.error('❌ All instructions require: --program-id and --authority');
         process.exit(1);
@@ -138,6 +155,8 @@ export function createRouterCommands(): Command {
         createLookupTableCommand(options, command);
       } else if (i === 'append-to-lookup-table') {
         appendToLookupTableCommand(options, command);
+      } else if (i === 'inspect-token') {
+        inspectTokenCommand(options, command);
       }
     });
 

--- a/src/commands/router/inspect-token.ts
+++ b/src/commands/router/inspect-token.ts
@@ -1,0 +1,182 @@
+import { Command } from 'commander';
+import { Connection, PublicKey } from '@solana/web3.js';
+import { validateArgs } from '../../utils/validation.js';
+import { InspectTokenArgsSchema } from '../../types/index.js';
+import { logger } from '../../utils/logger.js';
+import { AccountDerivation as RouterDerivation } from '../../programs/router/accounts.js';
+import { AccountDerivation as PoolDerivation } from '../../programs/burnmint-token-pool/accounts.js';
+import { deserializeTokenAdminRegistry } from '../../programs/router/registry.js';
+import { deserializePoolState } from '../../programs/shared/pool-state.js';
+import { readMint, readMultisigIfAny } from '../../utils/token.js';
+import { deriveCcipBaseAddresses } from '../../utils/alt.js';
+
+const NONE = PublicKey.default; // 11111111111111111111111111111111
+
+/**
+ * Read-only auditor: reports, for a mint, the CCIP token admin registry, the pool state, the mint
+ * authority (incl. SPL multisig members), and the ALT — to verify a deployment's governance config.
+ */
+export async function inspectTokenCommand(
+  options: Record<string, string>,
+  command: Command
+): Promise<void> {
+  try {
+    const global = command.parent?.opts() || {};
+
+    const parsed = validateArgs(InspectTokenArgsSchema, {
+      programId: options.programId,
+      mint: options.mint,
+      poolProgramId: options.poolProgramId,
+      feeQuoterProgramId: options.feeQuoterProgramId,
+      rpcUrl: global.resolvedRpcUrl,
+    });
+    if (!parsed.success) {
+      console.error(`❌ Invalid arguments: ${parsed.errors.join(', ')}`);
+      process.exit(1);
+    }
+
+    const {
+      programId: routerProgramId,
+      mint,
+      poolProgramId,
+      feeQuoterProgramId,
+      rpcUrl,
+    } = parsed.data;
+    const rpc = rpcUrl ?? (global.resolvedRpcUrl as string);
+    const connection = new Connection(rpc, 'confirmed');
+
+    // Build a label map of known derived addresses for friendly annotation.
+    const [poolStatePda] = PoolDerivation.deriveStatePda(poolProgramId, mint);
+    const [poolSignerPda] = PoolDerivation.derivePoolSignerPda(poolProgramId, mint);
+    const [registryPda] = RouterDerivation.deriveTokenAdminRegistryPda(routerProgramId, mint);
+    const labels = new Map<string, string>([
+      [poolSignerPda.toBase58(), 'Pool Signer PDA'],
+      [poolStatePda.toBase58(), 'Pool Config PDA'],
+      [registryPda.toBase58(), 'Token Admin Registry PDA'],
+      [mint.toBase58(), 'Token Mint'],
+    ]);
+    const lbl = (pk: PublicKey): string => {
+      const l = labels.get(pk.toBase58());
+      return l ? `  ← ${l}` : '';
+    };
+
+    console.log('🔎 CCIP Token Configuration Inspector');
+    console.log(`   Mint:            ${mint.toBase58()}`);
+    console.log(`   Router program:  ${routerProgramId.toBase58()}`);
+    console.log(`   Pool program:    ${poolProgramId.toBase58()}`);
+    console.log('');
+
+    // ── Mint authority ───────────────────────────────────────────────
+    console.log('═══ MINT ═══');
+    const mintInfo = await readMint(connection, mint);
+    console.log(`  Token Program:    ${mintInfo.tokenProgramId.toBase58()}`);
+    console.log(`  Decimals:         ${mintInfo.decimals}`);
+    console.log(`  Supply:           ${mintInfo.supply.toString()}`);
+    if (mintInfo.mintAuthority) {
+      console.log(
+        `  Mint Authority:   ${mintInfo.mintAuthority.toBase58()}${lbl(mintInfo.mintAuthority)}`
+      );
+      const ms = await readMultisigIfAny(connection, mintInfo.mintAuthority);
+      if (ms) {
+        console.log(`     └─ SPL Token multisig (threshold ${ms.m} of ${ms.n}):`);
+        ms.signers.forEach((s, i) =>
+          console.log(`        member ${i + 1}: ${s.toBase58()}${lbl(s)}`)
+        );
+      } else {
+        console.log('     └─ (not an SPL multisig — plain wallet / PDA / Squads vault)');
+      }
+    } else {
+      console.log('  Mint Authority:   none (fixed supply)');
+    }
+    console.log(
+      `  Freeze Authority: ${mintInfo.freezeAuthority ? mintInfo.freezeAuthority.toBase58() : 'none'}`
+    );
+    console.log('');
+
+    // ── Pool state ───────────────────────────────────────────────────
+    console.log(`═══ POOL STATE ═══`);
+    const poolAcc = await connection.getAccountInfo(poolStatePda);
+    if (!poolAcc) {
+      console.log(`  ⚠️  Pool not initialized (no account at ${poolStatePda.toBase58()})`);
+    } else {
+      const s = deserializePoolState(poolAcc.data).config;
+      const poolTokenExists = (await connection.getAccountInfo(s.poolTokenAccount)) !== null;
+      console.log(`  Pool Config PDA:  ${poolStatePda.toBase58()}`);
+      console.log(`  Owner:            ${s.owner.toBase58()}${lbl(s.owner)}`);
+      console.log(
+        `  Proposed Owner:   ${s.proposedOwner.equals(NONE) ? 'None' : s.proposedOwner.toBase58()}`
+      );
+      console.log(`  Rate Limit Admin: ${s.rateLimitAdmin.toBase58()}${lbl(s.rateLimitAdmin)}`);
+      console.log(`  Pool Signer PDA:  ${s.poolSigner.toBase58()}${lbl(s.poolSigner)}`);
+      console.log(
+        `  Pool Token Acct:  ${s.poolTokenAccount.toBase58()} (exists: ${poolTokenExists ? 'yes ✅' : 'NO ⚠️'})`
+      );
+    }
+    console.log('');
+
+    // ── Token admin registry ─────────────────────────────────────────
+    console.log('═══ TOKEN ADMIN REGISTRY ═══');
+    const regAcc = await connection.getAccountInfo(registryPda);
+    let lookupTable: PublicKey | null = null;
+    let writableIndexes: number[] = [];
+    if (!regAcc) {
+      console.log(
+        `  ⚠️  Token NOT registered with the CCIP router (no account at ${registryPda.toBase58()})`
+      );
+    } else {
+      const reg = deserializeTokenAdminRegistry(regAcc.data);
+      const layoutOk = reg.mint.equals(mint);
+      console.log(`  Registry PDA:     ${registryPda.toBase58()}`);
+      console.log(`  Version:          ${reg.version}`);
+      console.log(`  Administrator:    ${reg.administrator.toBase58()}${lbl(reg.administrator)}`);
+      console.log(
+        `  Pending Admin:    ${reg.pendingAdministrator.equals(NONE) ? 'None' : reg.pendingAdministrator.toBase58()}`
+      );
+      const hasAlt = !reg.lookupTable.equals(NONE);
+      console.log(
+        `  Lookup Table:     ${hasAlt ? reg.lookupTable.toBase58() : 'None (set_pool not done)'}`
+      );
+      console.log(`  Writable Indexes: [${reg.writableIndexes.join(', ')}]`);
+      console.log(`  Layout self-check (mint matches): ${layoutOk ? 'PASS ✅' : 'FAIL ❌'}`);
+      if (hasAlt) lookupTable = reg.lookupTable;
+      writableIndexes = reg.writableIndexes;
+    }
+    console.log('');
+
+    // ── Address Lookup Table ─────────────────────────────────────────
+    if (lookupTable) {
+      console.log('═══ ADDRESS LOOKUP TABLE ═══');
+      const altLabels = new Map<string, string>();
+      if (feeQuoterProgramId) {
+        const base = await deriveCcipBaseAddresses({
+          connection,
+          routerProgramId,
+          feeQuoterProgramId,
+          poolProgramId,
+          tokenMint: mint,
+          lookupTableAddress: lookupTable,
+        });
+        base.addresses.forEach((a, i) => altLabels.set(a.toBase58(), base.addressLabels[i] ?? ''));
+      }
+      const alt = await connection.getAddressLookupTable(lookupTable);
+      const addrs = alt.value?.state.addresses ?? [];
+      console.log(`  ${lookupTable.toBase58()} (${addrs.length} addresses)`);
+      addrs.forEach((a, i) => {
+        const w = writableIndexes.includes(i) ? ' [W]' : '';
+        const role = altLabels.get(a.toBase58());
+        console.log(
+          `   ${String(i).padStart(2)}${w.padEnd(4)} ${a.toBase58()}${role ? `  ← ${role}` : ''}`
+        );
+      });
+      console.log('');
+    }
+
+    console.log('✅ Inspection complete.');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error({ error: message }, 'inspectToken failed');
+    if (error instanceof Error && error.stack) logger.error({ stack: error.stack }, 'Stack trace');
+    console.error(`❌ ${message}`);
+    process.exit(1);
+  }
+}

--- a/src/commands/shared/create-token-account.ts
+++ b/src/commands/shared/create-token-account.ts
@@ -1,0 +1,91 @@
+import { Connection } from '@solana/web3.js';
+import type { TransactionOptions } from '../../types/index.js';
+import { CreateTokenAccountArgsSchema } from '../../types/index.js';
+import { validateArgs } from '../../utils/validation.js';
+import { createChildLogger, logger } from '../../utils/logger.js';
+import { finalizeTransaction } from '../../utils/finalize-transaction.js';
+import { TransactionBuilder } from '../../core/transaction-builder.js';
+import { type ProgramName } from '../../types/program-registry.js';
+import type { CommandContext, CreateTokenAccountOptions } from '../../types/command.js';
+import { detectTokenProgramId, findAssociatedTokenAddress } from '../../utils/token.js';
+import { InstructionBuilder as SplInstructionBuilder } from '../../programs/spl-token/instructions.js';
+import { AccountDerivation as BurnmintDerivation } from '../../programs/burnmint-token-pool/accounts.js';
+import { AccountDerivation as LockreleaseDerivation } from '../../programs/lockrelease-token-pool/accounts.js';
+
+/**
+ * Shared implementation: create the pool signer's Associated Token Account (the pool's token
+ * reserve account). Works for both SPL Token and Token-2022 (program auto-detected from the mint),
+ * and supports both Base58 (Squads) output and --execute. Idempotent: safe to re-run.
+ */
+export async function createTokenAccount(
+  options: CreateTokenAccountOptions,
+  command: CommandContext,
+  programType: ProgramName
+): Promise<void> {
+  const cmdLogger = createChildLogger(logger, { command: `${programType}.create-token-account` });
+
+  try {
+    const globalOptions = command.parent?.parent?.opts() || command.parent?.opts() || {};
+
+    const parsed = validateArgs(CreateTokenAccountArgsSchema, {
+      programId: options.programId,
+      mint: options.mint,
+      authority: options.authority,
+      rpcUrl: globalOptions.resolvedRpcUrl!,
+    });
+
+    if (!parsed.success) {
+      console.error(`❌ Invalid arguments: ${parsed.errors.join(', ')}`);
+      process.exit(1);
+    }
+
+    const { programId, mint, authority, rpcUrl } = parsed.data;
+    const rpc = rpcUrl ?? (globalOptions.resolvedRpcUrl as string);
+
+    // Detect SPL Token vs Token-2022 from the mint
+    const connection = new Connection(rpc);
+    const tokenProgramId = await detectTokenProgramId(connection, mint);
+
+    // Owner of the ATA is the pool signer PDA (program-specific)
+    const [poolSigner] =
+      programType === 'burnmint-token-pool'
+        ? BurnmintDerivation.derivePoolSignerPda(programId, mint)
+        : LockreleaseDerivation.derivePoolSignerPda(programId, mint);
+
+    const ata = findAssociatedTokenAddress(mint, poolSigner, tokenProgramId);
+
+    const builder = new SplInstructionBuilder(tokenProgramId);
+    const ix = builder.createAssociatedTokenAccountIdempotentWithAddress(
+      authority,
+      ata,
+      poolSigner,
+      mint
+    );
+
+    console.log('🔄 Generating create pool token account transaction...');
+    console.log(`   Token Program:            ${tokenProgramId.toBase58()}`);
+    console.log(`   Pool Signer (ATA owner):  ${poolSigner.toBase58()}`);
+    console.log(`   Pool Token Account (ATA): ${ata.toBase58()}`);
+
+    const txOptions: TransactionOptions = { rpcUrl: rpc };
+    const txBuilder = new TransactionBuilder(txOptions);
+
+    console.log('🔄 Building and simulating transaction...');
+    await finalizeTransaction({
+      txBuilder,
+      instructions: [ix],
+      payer: authority,
+      instructionName: `${programType}.create-token-account`,
+      command,
+    });
+    console.log('   ✅ Transaction simulation completed');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    cmdLogger.error({ error: message }, 'createTokenAccount failed');
+    if (error instanceof Error && error.stack) {
+      cmdLogger.error({ stack: error.stack }, 'Stack trace');
+    }
+    console.error(`❌ ${message}`);
+    process.exit(1);
+  }
+}

--- a/src/commands/shared/get-state.ts
+++ b/src/commands/shared/get-state.ts
@@ -6,6 +6,10 @@ import { getProgramConfig, type ProgramName } from '../../types/program-registry
 import type { CommandContext, GetStateOptions } from '../../types/command.js';
 import { AccountDerivation as BurnmintDerivation } from '../../programs/burnmint-token-pool/accounts.js';
 import { AccountDerivation as LockreleaseDerivation } from '../../programs/lockrelease-token-pool/accounts.js';
+import {
+  deserializePoolState,
+  type PoolStateAccount as StateAccount,
+} from '../../programs/shared/pool-state.js';
 
 /**
  * Shared get state implementation for reading on-chain state accounts
@@ -94,7 +98,7 @@ export async function getState(
     console.log('');
 
     // Deserialize account data manually
-    const stateAccount = deserializeStateAccount(accountInfo.data);
+    const stateAccount = deserializePoolState(accountInfo.data);
 
     cmdLogger.debug({ stateAccount }, 'State account deserialized successfully');
 
@@ -125,119 +129,6 @@ export async function getState(
     }
     process.exit(1);
   }
-}
-
-/**
- * State account structure from IDL
- */
-interface StateAccount {
-  version: number;
-  config: {
-    tokenProgram: PublicKey;
-    mint: PublicKey;
-    decimals: number;
-    poolSigner: PublicKey;
-    poolTokenAccount: PublicKey;
-    owner: PublicKey;
-    proposedOwner: PublicKey;
-    rateLimitAdmin: PublicKey;
-    routerOnrampAuthority: PublicKey;
-    router: PublicKey;
-    rebalancer?: PublicKey;
-    canAcceptLiquidity?: boolean;
-    listEnabled: boolean;
-    allowList: PublicKey[];
-    rmnRemote: PublicKey;
-  };
-}
-
-/**
- * Manually deserialize State account data
- * Avoids BorshAccountsCoder issues with incomplete IDL types
- *
- * @param data - Raw account data buffer from the blockchain
- * @returns Deserialized state account object
- */
-function deserializeStateAccount(data: Buffer): StateAccount {
-  let offset = 8; // Skip 8-byte Anchor discriminator
-
-  // Read version (u8)
-  const version = data.readUInt8(offset);
-  offset += 1;
-
-  // Read BaseConfig fields
-  const tokenProgram = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  const mint = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  const decimals = data.readUInt8(offset);
-  offset += 1;
-
-  const poolSigner = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  const poolTokenAccount = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  const owner = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  const proposedOwner = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  const rateLimitAdmin = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  const routerOnrampAuthority = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  const router = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  const rebalancer = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  const canAcceptLiquidity = data.readUInt8(offset) === 1;
-  offset += 1;
-
-  const listEnabled = data.readUInt8(offset) === 1;
-  offset += 1;
-
-  // Read Vec<Pubkey> for allowList
-  const allowListLength = data.readUInt32LE(offset);
-  offset += 4;
-
-  const allowList: PublicKey[] = [];
-  for (let i = 0; i < allowListLength; i++) {
-    allowList.push(new PublicKey(data.subarray(offset, offset + 32)));
-    offset += 32;
-  }
-
-  const rmnRemote = new PublicKey(data.subarray(offset, offset + 32));
-  offset += 32;
-
-  return {
-    version,
-    config: {
-      tokenProgram,
-      mint,
-      decimals,
-      poolSigner,
-      poolTokenAccount,
-      owner,
-      proposedOwner,
-      rateLimitAdmin,
-      routerOnrampAuthority,
-      router,
-      rebalancer,
-      canAcceptLiquidity,
-      listEnabled,
-      allowList,
-      rmnRemote,
-    },
-  };
 }
 
 /**

--- a/src/commands/spl-token/create-mint.ts
+++ b/src/commands/spl-token/create-mint.ts
@@ -5,11 +5,8 @@ import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { CreateMintArgsSchema } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
-import {
-  TOKEN_PROGRAM_ID,
-  TOKEN_2022_PROGRAM_ID,
-  ASSOCIATED_TOKEN_PROGRAM_ID,
-} from '@solana/spl-token';
+import { TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID } from '@solana/spl-token';
+import { findAssociatedTokenAddress } from '../../utils/token.js';
 import { InstructionBuilder as SplInstructionBuilder } from '../../programs/spl-token/instructions.js';
 
 // Type for validated create mint parameters
@@ -41,21 +38,6 @@ import {
   percentAmount,
 } from '@metaplex-foundation/umi';
 import { toWeb3JsInstruction } from '@metaplex-foundation/umi-web3js-adapters';
-
-/**
- * Calculate ATA address without curve validation (for instruction building)
- */
-function findAssociatedTokenAddress(
-  mint: PublicKey,
-  owner: PublicKey,
-  tokenProgramId: PublicKey
-): PublicKey {
-  const [address] = PublicKey.findProgramAddressSync(
-    [owner.toBuffer(), tokenProgramId.toBuffer(), mint.toBuffer()],
-    ASSOCIATED_TOKEN_PROGRAM_ID
-  );
-  return address;
-}
 
 export async function createMintCommand(options: Record<string, string>, command: Command) {
   const global = command.parent?.opts() || {};

--- a/src/commands/spl-token/mint.ts
+++ b/src/commands/spl-token/mint.ts
@@ -1,28 +1,13 @@
 import { Command } from 'commander';
 import { Connection, PublicKey, TransactionInstruction } from '@solana/web3.js';
-import { getAccount, ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import { detectTokenProgramId } from '../../utils/token.js';
+import { getAccount } from '@solana/spl-token';
+import { detectTokenProgramId, findAssociatedTokenAddress } from '../../utils/token.js';
 import { SplMintArgsSchema } from '../../types/index.js';
 import { validateArgs } from '../../utils/validation.js';
 import { TransactionBuilder } from '../../core/transaction-builder.js';
 import { finalizeTransaction } from '../../utils/finalize-transaction.js';
 import { logger } from '../../utils/logger.js';
 import { InstructionBuilder as SplInstructionBuilder } from '../../programs/spl-token/instructions.js';
-
-/**
- * Calculate ATA address without curve validation (for instruction building)
- */
-function findAssociatedTokenAddress(
-  mint: PublicKey,
-  owner: PublicKey,
-  tokenProgramId: PublicKey
-): PublicKey {
-  const [address] = PublicKey.findProgramAddressSync(
-    [owner.toBuffer(), tokenProgramId.toBuffer(), mint.toBuffer()],
-    ASSOCIATED_TOKEN_PROGRAM_ID
-  );
-  return address;
-}
 
 export async function mintCommand(options: Record<string, string>, command: Command) {
   try {

--- a/src/programs/router/registry.ts
+++ b/src/programs/router/registry.ts
@@ -1,0 +1,56 @@
+import { PublicKey } from '@solana/web3.js';
+
+/**
+ * Decoded CCIP Token Admin Registry account.
+ *
+ * The router IDL bundled in this repo does not include this account layout, so it is decoded by
+ * byte offset. The layout must stay in sync with the on-chain Rust program.
+ */
+export interface TokenAdminRegistry {
+  version: number;
+  administrator: PublicKey;
+  pendingAdministrator: PublicKey;
+  lookupTable: PublicKey;
+  /** Account indexes (into the ALT) that are marked writable for set_pool. */
+  writableIndexes: number[];
+  mint: PublicKey;
+}
+
+/**
+ * Decode the `writable_indexes` region ([u128; 2], 32 bytes) into a sorted list of account indexes.
+ *
+ * Encoding (verified on-chain against a known set-pool of [3,4,7]): each u128 is a bitmap where the
+ * MOST significant bit corresponds to index 0, i.e. account index `i` is stored at bit `127 - i` of
+ * its word. Word 0 (bytes 0-15) covers indexes 0-127; word 1 (bytes 16-31) covers 128-255.
+ */
+export function decodeWritableIndexes(buf: Buffer): number[] {
+  const indexes: number[] = [];
+  for (let b = 0; b < 32; b++) {
+    const byte = buf[b] ?? 0;
+    for (let i = 0; i < 8; i++) {
+      if (byte & (1 << i)) {
+        const bitPos = (b % 16) * 8 + i; // position within the u128 (0-127)
+        const index = b < 16 ? 127 - bitPos : 255 - bitPos;
+        indexes.push(index);
+      }
+    }
+  }
+  return indexes.sort((a, b) => a - b);
+}
+
+/**
+ * Manually deserialize a Token Admin Registry account.
+ * Layout: 8 disc | version u8 | administrator(32) | pending_administrator(32) | lookup_table(32) |
+ * writable_indexes [u128;2] (32) | mint(32).
+ */
+export function deserializeTokenAdminRegistry(data: Buffer): TokenAdminRegistry {
+  const pk = (offset: number): PublicKey => new PublicKey(data.subarray(offset, offset + 32));
+  return {
+    version: data.readUInt8(8),
+    administrator: pk(9),
+    pendingAdministrator: pk(41),
+    lookupTable: pk(73),
+    writableIndexes: decodeWritableIndexes(data.subarray(105, 137) as Buffer),
+    mint: pk(137),
+  };
+}

--- a/src/programs/shared/pool-state.ts
+++ b/src/programs/shared/pool-state.ts
@@ -1,0 +1,115 @@
+import { PublicKey } from '@solana/web3.js';
+
+/**
+ * On-chain token pool State account (shared layout for burnmint and lockrelease pools).
+ */
+export interface PoolStateAccount {
+  version: number;
+  config: {
+    tokenProgram: PublicKey;
+    mint: PublicKey;
+    decimals: number;
+    poolSigner: PublicKey;
+    poolTokenAccount: PublicKey;
+    owner: PublicKey;
+    proposedOwner: PublicKey;
+    rateLimitAdmin: PublicKey;
+    routerOnrampAuthority: PublicKey;
+    router: PublicKey;
+    rebalancer?: PublicKey;
+    canAcceptLiquidity?: boolean;
+    listEnabled: boolean;
+    allowList: PublicKey[];
+    rmnRemote: PublicKey;
+  };
+}
+
+/**
+ * Manually deserialize a pool State account.
+ *
+ * Avoids BorshAccountsCoder issues with incomplete IDL types; the byte layout must stay in sync with
+ * the on-chain Rust program. Shared by `get-state` and `inspect-token`.
+ *
+ * @param data - Raw account data buffer from the blockchain
+ */
+export function deserializePoolState(data: Buffer): PoolStateAccount {
+  let offset = 8; // Skip 8-byte Anchor discriminator
+
+  // Read version (u8)
+  const version = data.readUInt8(offset);
+  offset += 1;
+
+  // Read BaseConfig fields
+  const tokenProgram = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  const mint = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  const decimals = data.readUInt8(offset);
+  offset += 1;
+
+  const poolSigner = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  const poolTokenAccount = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  const owner = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  const proposedOwner = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  const rateLimitAdmin = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  const routerOnrampAuthority = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  const router = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  const rebalancer = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  const canAcceptLiquidity = data.readUInt8(offset) === 1;
+  offset += 1;
+
+  const listEnabled = data.readUInt8(offset) === 1;
+  offset += 1;
+
+  // Read Vec<Pubkey> for allowList
+  const allowListLength = data.readUInt32LE(offset);
+  offset += 4;
+
+  const allowList: PublicKey[] = [];
+  for (let i = 0; i < allowListLength; i++) {
+    allowList.push(new PublicKey(data.subarray(offset, offset + 32)));
+    offset += 32;
+  }
+
+  const rmnRemote = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  return {
+    version,
+    config: {
+      tokenProgram,
+      mint,
+      decimals,
+      poolSigner,
+      poolTokenAccount,
+      owner,
+      proposedOwner,
+      rateLimitAdmin,
+      routerOnrampAuthority,
+      router,
+      rebalancer,
+      canAcceptLiquidity,
+      listEnabled,
+      allowList,
+      rmnRemote,
+    },
+  };
+}

--- a/src/programs/spl-token/instructions.ts
+++ b/src/programs/spl-token/instructions.ts
@@ -5,6 +5,7 @@ import {
   createSetAuthorityInstruction,
   createInitializeMintInstruction,
   createAssociatedTokenAccountInstruction,
+  createAssociatedTokenAccountIdempotentInstruction,
   createApproveInstruction,
   getAssociatedTokenAddressSync,
   getMintLen,
@@ -200,6 +201,25 @@ export class InstructionBuilder {
     mint: PublicKey
   ): TransactionInstruction {
     return createAssociatedTokenAccountInstruction(
+      payer,
+      associatedTokenAddress,
+      owner,
+      mint,
+      this.tokenProgramId
+    );
+  }
+
+  /**
+   * Create an ATA idempotently (no error if it already exists), with a pre-calculated address.
+   * Used for the pool signer's token account, whose owner is an off-curve PDA.
+   */
+  createAssociatedTokenAccountIdempotentWithAddress(
+    payer: PublicKey,
+    associatedTokenAddress: PublicKey,
+    owner: PublicKey,
+    mint: PublicKey
+  ): TransactionInstruction {
+    return createAssociatedTokenAccountIdempotentInstruction(
       payer,
       associatedTokenAddress,
       owner,

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -33,6 +33,17 @@ export interface InitializePoolOptions {
   authority: string;
 }
 
+/** Options for create-token-account (same shape as initialize-pool). */
+export type CreateTokenAccountOptions = InitializePoolOptions;
+
+/** Options for the read-only inspect-token auditor. */
+export interface InspectTokenOptions {
+  programId: string; // router program
+  mint: string;
+  poolProgramId: string;
+  feeQuoterProgramId?: string;
+}
+
 /**
  * Standard options for accept ownership commands
  */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,9 @@ export const BurnmintInitializePoolArgsSchema = BaseInitializePoolArgsSchema;
 // Lockrelease initialize pool (uses base schema)
 export const LockreleaseInitializePoolArgsSchema = BaseInitializePoolArgsSchema;
 
+// create-token-account: same args as initialize-pool (programId, mint, authority)
+export const CreateTokenAccountArgsSchema = BaseInitializePoolArgsSchema;
+
 export const TransferOwnershipArgsSchema = z.object({
   programId: z.string().transform(val => new PublicKey(val)),
   mint: z.string().transform(val => new PublicKey(val)),
@@ -95,6 +98,30 @@ export const SetRateLimitAdminArgsSchema = z.object({
 export const GetStateArgsSchema = z.object({
   programId: z.string().transform(val => new PublicKey(val)),
   mint: z.string().transform(val => new PublicKey(val)),
+  rpcUrl: z
+    .string()
+    .refine(
+      val => {
+        try {
+          new URL(val);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { message: 'Invalid URL format' }
+    )
+    .optional(),
+});
+
+export const InspectTokenArgsSchema = z.object({
+  programId: z.string().transform(val => new PublicKey(val)), // router program
+  mint: z.string().transform(val => new PublicKey(val)),
+  poolProgramId: z.string().transform(val => new PublicKey(val)),
+  feeQuoterProgramId: z
+    .string()
+    .transform(val => new PublicKey(val))
+    .optional(),
   rpcUrl: z
     .string()
     .refine(

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,5 +1,12 @@
 import { Connection, PublicKey } from '@solana/web3.js';
-import { TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID } from '@solana/spl-token';
+import {
+  TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  MULTISIG_SIZE,
+  getMint,
+  getMultisig,
+} from '@solana/spl-token';
 import { logger } from './logger.js';
 
 export async function detectTokenProgramId(
@@ -23,4 +30,70 @@ export async function detectTokenProgramId(
   const message = `Unsupported token program for mint ${mint.toBase58()}: ${owner.toBase58()}`;
   logger.error(message);
   throw new Error(message);
+}
+
+/**
+ * Calculate the Associated Token Account address without on-curve validation
+ * (works for both SPL Token and Token-2022 via the passed tokenProgramId).
+ */
+export function findAssociatedTokenAddress(
+  mint: PublicKey,
+  owner: PublicKey,
+  tokenProgramId: PublicKey
+): PublicKey {
+  const [address] = PublicKey.findProgramAddressSync(
+    [owner.toBuffer(), tokenProgramId.toBuffer(), mint.toBuffer()],
+    ASSOCIATED_TOKEN_PROGRAM_ID
+  );
+  return address;
+}
+
+/** Decoded summary of a mint account (program-agnostic). */
+export interface MintSummary {
+  tokenProgramId: PublicKey;
+  mintAuthority: PublicKey | null;
+  freezeAuthority: PublicKey | null;
+  decimals: number;
+  supply: bigint;
+}
+
+/**
+ * Read a mint account, auto-detecting whether it is owned by SPL Token or Token-2022.
+ */
+export async function readMint(connection: Connection, mint: PublicKey): Promise<MintSummary> {
+  const tokenProgramId = await detectTokenProgramId(connection, mint);
+  const info = await getMint(connection, mint, undefined, tokenProgramId);
+  return {
+    tokenProgramId,
+    mintAuthority: info.mintAuthority,
+    freezeAuthority: info.freezeAuthority,
+    decimals: info.decimals,
+    supply: info.supply,
+  };
+}
+
+/** Decoded SPL Token multisig (threshold + members). */
+export interface MultisigSummary {
+  m: number;
+  n: number;
+  signers: PublicKey[];
+}
+
+/**
+ * If the given address is an initialized SPL Token / Token-2022 multisig account, decode its
+ * threshold and members; otherwise return null (e.g. it is a plain wallet, PDA, or Squads vault).
+ */
+export async function readMultisigIfAny(
+  connection: Connection,
+  address: PublicKey
+): Promise<MultisigSummary | null> {
+  const info = await connection.getAccountInfo(address);
+  if (!info) return null;
+  const isTokenProgram =
+    info.owner.equals(TOKEN_PROGRAM_ID) || info.owner.equals(TOKEN_2022_PROGRAM_ID);
+  if (!isTokenProgram || info.data.length !== MULTISIG_SIZE) return null;
+  const ms = await getMultisig(connection, address, undefined, info.owner);
+  if (!ms.isInitialized) return null;
+  const signers = Array.from({ length: ms.n }, (_, i) => ms[`signer${i + 1}` as keyof typeof ms]);
+  return { m: ms.m, n: ms.n, signers: signers as PublicKey[] };
 }


### PR DESCRIPTION
This pull request adds new "Create Token Account" and "Inspect Token" commands to the CLI, improves documentation, and updates command routing and validation logic to support these features. These changes make it easier to create pool token accounts for both burn/mint and lock/release pools, and to audit token configurations with a read-only inspector.

**New CLI commands and handlers:**

* Added a `create-token-account` command for both `burnmint-token-pool` and `lockrelease-token-pool`, with dedicated handlers and documentation. This command creates the pool signer's Associated Token Account, required for liquidity operations. [[1]](diffhunk://#diff-48afad3422fb8ee0b755dc35d9ab4cd085da07fbf326e6d2ac7491049bcc7261R1-R9) [[2]](diffhunk://#diff-c3ff58d34a00c969bc093bee3827265d8a6e2a2f7b6eb70b6386bf0d87093971R6) [[3]](diffhunk://#diff-c3ff58d34a00c969bc093bee3827265d8a6e2a2f7b6eb70b6386bf0d87093971L26-R27) [[4]](diffhunk://#diff-c3ff58d34a00c969bc093bee3827265d8a6e2a2f7b6eb70b6386bf0d87093971R462-R463) [[5]](diffhunk://#diff-c3ff58d34a00c969bc093bee3827265d8a6e2a2f7b6eb70b6386bf0d87093971L488-R491) [[6]](diffhunk://#diff-53b2981b44db759a814faa6f9f604630eac83543dfdc24dda62ef9475ed94af1R1-R9) [[7]](diffhunk://#diff-204e8c6a83aac13fdcac48008301204020e62c7265eac77cb1be4752311d0efdR3) [[8]](diffhunk://#diff-204e8c6a83aac13fdcac48008301204020e62c7265eac77cb1be4752311d0efdL30-R31) [[9]](diffhunk://#diff-204e8c6a83aac13fdcac48008301204020e62c7265eac77cb1be4752311d0efdR221-R222) [[10]](diffhunk://#diff-204e8c6a83aac13fdcac48008301204020e62c7265eac77cb1be4752311d0efdL255-R258) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24) [[12]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40) [[13]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R252-R283) [[14]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R938-R950)
* Added an `inspect-token` read-only auditor command to the `router` CLI, which reports a token's full CCIP configuration and governance/ownership state. This command cannot be executed with `--execute` and requires no authority. [[1]](diffhunk://#diff-4ec98b9e344350332e3561ccd9367db00f3c9f37ebc9fdf125470e4c6365c127R9) [[2]](diffhunk://#diff-4ec98b9e344350332e3561ccd9367db00f3c9f37ebc9fdf125470e4c6365c127L20-R21) [[3]](diffhunk://#diff-4ec98b9e344350332e3561ccd9367db00f3c9f37ebc9fdf125470e4c6365c127R65-L67) [[4]](diffhunk://#diff-4ec98b9e344350332e3561ccd9367db00f3c9f37ebc9fdf125470e4c6365c127R158-R159) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R65) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1615-R1655)

**Documentation improvements:**

* Updated `README.md` to document the new commands, their syntax, options, and usage examples for both burnmint and lockrelease pools, as well as the new inspect-token feature. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R65) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R252-R283) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R938-R950) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1615-R1655)
* Clarified CLI authority handling: `--authority` is now optional in `--execute` mode and defaults to the loaded keypair; added details about keypair usage, simulation, and read-only command restrictions.

**Validation and routing logic:**

* Updated CLI instruction routing to support the new commands and improved error messages for unknown instructions. [[1]](diffhunk://#diff-c3ff58d34a00c969bc093bee3827265d8a6e2a2f7b6eb70b6386bf0d87093971R462-R463) [[2]](diffhunk://#diff-c3ff58d34a00c969bc093bee3827265d8a6e2a2f7b6eb70b6386bf0d87093971L488-R491) [[3]](diffhunk://#diff-204e8c6a83aac13fdcac48008301204020e62c7265eac77cb1be4752311d0efdR221-R222) [[4]](diffhunk://#diff-204e8c6a83aac13fdcac48008301204020e62c7265eac77cb1be4752311d0efdL255-R258) [[5]](diffhunk://#diff-4ec98b9e344350332e3561ccd9367db00f3c9f37ebc9fdf125470e4c6365c127R65-L67)
* Enforced that `inspect-token` cannot be run with `--execute` and requires specific arguments, with clear error messages.

These changes improve usability and safety for pool management and token audits, and ensure the CLI stays up to date with new program features.